### PR TITLE
add performance tests for pyspark

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -328,6 +328,50 @@ def run_tests(test_jar, tests_to_run, test_group_name, output_processing_functio
     print(output_divider_string)
 
 
+def run_python_tests(tests, test_group_name, output_processing_function, output_filename):
+    output_dirname = output_filename + "_logs"
+    os.makedirs(output_dirname)
+    out_file = open(output_filename, 'w')
+    num_tests_to_run = len(tests)
+
+    output_divider_string = "--------------------------------------------------------------------"
+    print(output_divider_string)
+    print("Running %d tests in %s.\n" % (num_tests_to_run, test_group_name))
+
+    for short_name, scripts, scale_factor, java_opt_sets, opt_sets in tests:
+        print(output_divider_string)
+        print("Running test command: '%s' ..." % scripts)
+        stdout_filename = "%s/%s.out" % (output_dirname, short_name)
+        stderr_filename = "%s/%s.err" % (output_dirname, short_name)
+
+        # Run a test for all combinations of the OptionSets given, then capture
+        # and print the output.
+        java_opt_set_arrays = [i.to_array(scale_factor) for i in java_opt_sets]
+        opt_set_arrays = [i.to_array(scale_factor) for i in opt_sets]
+        for java_opt_list in itertools.product(*java_opt_set_arrays):
+            for opt_list in itertools.product(*opt_set_arrays):
+                ensure_spark_stopped_on_slaves(slaves_list)
+                append_config_to_file(stdout_filename, java_opt_list, opt_list)
+                append_config_to_file(stderr_filename, java_opt_list, opt_list)
+                test_env["SPARK_SUBMIT_OPTS"] = " ".join(java_opt_list)
+                spark_submit = "%s/bin/spark-submit" % effective_spark_home
+                cmd = "%s --master %s pyspark-tests/%s %s 1>> %s 2>> %s" % (
+                    spark_submit, config.SPARK_CLUSTER_URL, scripts, " ".join(opt_list),
+                    stdout_filename, stderr_filename)
+
+                print("\nRunning command: %s\n" % cmd)
+                Popen(cmd, shell=True, env=test_env).wait()
+                result_string = output_processing_function(short_name, opt_list, stdout_filename, stderr_filename)
+                print(output_divider_string)
+                print("\nResult: " + result_string)
+                print(output_divider_string)
+                out_file.write(result_string + "\n")
+                out_file.flush()
+
+    print("\nFinished running %d tests in %s.\nSee summary in %s" %
+          (num_tests_to_run, test_group_name, output_filename))
+    print(output_divider_string)
+
 # Function to process the output of multiple trials for Spark and Shark tests 
 def process_trials_output(short_name, opt_list, stdout_filename, stderr_filename):
     with open (stdout_filename, "r") as stdout_file:
@@ -371,6 +415,10 @@ if has_spark_tests:
     spark_test_jar = "%s/spark-tests/target/spark-perf-tests-assembly.jar" % proj_dir
     run_tests(spark_test_jar, config.SPARK_TESTS, "Spark-Tests",
         process_trials_output, config.SPARK_OUTPUT_FILENAME)
+
+if config.PYSPARK_TESTS:
+    run_python_tests(config.PYSPARK_TESTS, "PySpark-Tests",
+                     process_trials_output, config.PYSPARK_OUTPUT_FILENAME)
 
 if has_streaming_tests:
     streaming_test_jar = "%s/streaming-tests/target/streaming-perf-tests-assembly.jar" % proj_dir

--- a/config/config.py.template
+++ b/config/config.py.template
@@ -45,6 +45,8 @@ SPARK_MERGE_COMMIT_INTO_MASTER = False # Whether to merge the commit into master
 # File to write results to.
 SPARK_OUTPUT_FILENAME = "results/spark_perf_output_%s_%s" % (
     SPARK_COMMIT_ID.replace("/", "-"), time.strftime("%Y-%m-%d_%H-%M-%S"))
+PYSPARK_OUTPUT_FILENAME = "results/python_perf_output_%s_%s" % (
+    SPARK_COMMIT_ID.replace("/", "-"), time.strftime("%Y-%m-%d_%H-%M-%S"))
 STREAMING_OUTPUT_FILENAME = "results/streaming_perf_output_%s_%s" % (
     SPARK_COMMIT_ID.replace("/", "-"), time.strftime("%Y-%m-%d_%H-%M-%S"))
 
@@ -162,6 +164,39 @@ SPARK_TESTS = []
 
 #SPARK_TESTS += [("scala-count-w-fltr", "spark.perf.TestRunner", SCALE_FACTOR,
 #    COMMON_JAVA_OPTS, [ConstantOption("count-with-filter")] + SPARK_KV_OPTS)]
+
+
+
+# PySpark tests
+PYSPARK_TESTS = []
+
+PYSPARK_TESTS += [("python-scheduling-throughput", "tests.py",
+    SCALE_FACTOR, COMMON_JAVA_OPTS,
+    [ConstantOption("SchedulerThroughputTest"), OptionSet("num-tasks", [5000])] + COMMON_OPTS)]
+
+PYSPARK_TESTS += [("python-agg-by-key", "tests.py", SCALE_FACTOR,
+    COMMON_JAVA_OPTS, [ConstantOption("AggregateByKey")] + SPARK_KV_OPTS)]
+
+# Scale the input for this test by 2x since ints are smaller.
+PYSPARK_TESTS += [("python-agg-by-key-int", "tests.py", SCALE_FACTOR * 2,
+    COMMON_JAVA_OPTS, [ConstantOption("AggregateByKeyInt")] + SPARK_KV_OPTS)]
+
+PYSPARK_TESTS += [("python-agg-by-key-naive", "tests.py", SCALE_FACTOR,
+    COMMON_JAVA_OPTS, [ConstantOption("AggregateByKeyNaive")] + SPARK_KV_OPTS)]
+
+# Scale the input for this test by 0.10.
+PYSPARK_TESTS += [("python-sort-by-key", "tests.py", SCALE_FACTOR * 0.1,
+    COMMON_JAVA_OPTS, [ConstantOption("SortByKey")] + SPARK_KV_OPTS)]
+
+PYSPARK_TESTS += [("python-sort-by-key-int", "tests.py", SCALE_FACTOR * 0.2,
+    COMMON_JAVA_OPTS, [ConstantOption("SortByKeyInt")] + SPARK_KV_OPTS)]
+
+PYSPARK_TESTS += [("python-count", "tests.py", SCALE_FACTOR,
+                 COMMON_JAVA_OPTS, [ConstantOption("Count")] + SPARK_KV_OPTS)]
+
+PYSPARK_TESTS += [("python-count-w-fltr", "tests.py", SCALE_FACTOR,
+    COMMON_JAVA_OPTS, [ConstantOption("CountWithFilter")] + SPARK_KV_OPTS)]
+
 
 
 # Spark Streaming tests #

--- a/pyspark-tests/tests.py
+++ b/pyspark-tests/tests.py
@@ -1,0 +1,152 @@
+import time
+import random
+
+import pyspark
+
+
+class DataGenerator:
+
+    def paddedString(self, i, length, doHash=False):
+        return ("%%0%dd" % length) % (hash(i) if doHash else i)
+
+    def generateIntData(self, sc, records, uniqueKeys, uniqueValues, numPartitions, seed):
+        n = records / numPartitions
+        def gen(index):
+            ran = random.Random(hash(str(seed ^ index)))
+            for i in range(n):
+                yield ran.randint(0, uniqueKeys), ran.randint(0, uniqueValues)
+        return sc.parallelize(range(numPartitions), numPartitions).flatMap(gen)
+
+    def createKVDataSet(self, sc, dataType, records, uniqueKeys, uniqueValues, keyLength,
+                              valueLength, numPartitions, randomSeed,
+                              persistenceType, storageLocation="/tmp/spark-perf-kv-data"):
+        inputRDD = self.generateIntData(sc, records, uniqueKeys, uniqueValues, numPartitions, randomSeed)
+        if dataType == "string":
+            inputRDD = inputRDD.map(lambda (k, v): (self.paddedString(k, keyLength),
+                                            self.paddedString(v, valueLength)))
+        if persistenceType == "memory":
+            rdd = inputRDD.persist(pyspark.StorageLevel.MEMORY_ONLY)
+        elif persistenceType == "disk":
+            rdd = inputRDD.persist(pyspark.StorageLevel.DISK_ONLY)
+        elif persistenceType == "hdfs":
+            pass
+        rdd.count()
+        return rdd
+
+
+class PerfTest:
+    def __init__(self, sc):
+        self.sc = sc
+
+    def initialize(self, options):
+        self.options = options
+
+    def createInputData(self):
+        pass
+
+    def run(self):
+        raise NotImplementedError
+
+
+class SchedulerThroughputTest(PerfTest):
+    def run(self):
+        options = self.options
+        rs = []
+        for i in range(options.num_trials):
+            start = time.time()
+            self.sc.parallelize(range(options.num_tasks), options.num_tasks).count()
+            rs.append(time.time() - start)
+            time.sleep(options.inter_trial_wait)
+        return rs
+
+
+class KVDataTest(PerfTest):
+    def __init__(self, sc, dataType="string"):
+        PerfTest.__init__(self, sc)
+        self.dataType = dataType
+
+    def createInputData(self):
+        options = self.options
+        self.rdd = DataGenerator().createKVDataSet(
+                self.sc, self.dataType, options.num_records,
+                options.unique_keys, options.unique_values,
+                options.key_length, options.value_length,
+                options.num_partitions, options.random_seed,
+                options.persistent_type, options.storage_location)
+
+    def runTest(self, rdd, reduceTasks):
+        raise NotImplementedError
+
+    def run(self):
+        options = self.options
+        used = []
+        for i in range(options.num_trials):
+            start = time.time()
+            self.runTest(self.rdd, options.reduce_tasks)
+            end = time.time()
+            used.append(end - start)
+            time.sleep(options.inter_trial_wait)
+        return used
+
+
+class KVDataTestInt(KVDataTest):
+    def __init__(self, sc):
+        KVDataTest.__init__(self, sc, "int")
+
+class AggregateByKey(KVDataTest):
+    def runTest(self, rdd, reduceTasks):
+        rdd.map(lambda (k, v): (k, int(v))).reduceByKey(lambda x, y: x + y, reduceTasks).count()
+
+class AggregateByKeyInt(KVDataTestInt):
+
+    def runTest(self, rdd, reduceTasks):
+        rdd.reduceByKey(lambda x, y: x + y, reduceTasks).count()
+
+class AggregateByKeyNaive(KVDataTest):
+    def runTest(self, rdd, reduceTasks):
+        rdd.map(lambda (k, v): (k, int(v))).groupByKey(reduceTasks).mapValues(sum).count()
+
+class SortByKey(KVDataTest):
+    def runTest(self, rdd, reduceTasks):
+        rdd.sortByKey(numPartitions=reduceTasks).count()
+
+class SortByKeyInt(KVDataTestInt):
+    def runTest(self, rdd, reduceTasks):
+        rdd.sortByKey(numPartitions=reduceTasks).count()
+
+class Count(KVDataTest):
+    def runTest(self, rdd, _):
+        rdd.count()
+
+class CountWithFilter(KVDataTest):
+    def runTest(self, rdd, _):
+        rdd.filter(lambda (k, v): int(v) % 2).count()
+
+if __name__ == "__main__":
+    import optparse
+    parser = optparse.OptionParser(usage="Usage: %prog [options] test_names")
+    parser.add_option("--num-trials", type="int", default=1)
+    parser.add_option("--num-tasks", type="int", default=4)
+    parser.add_option("--reduce-tasks", type="int", default=4)
+    parser.add_option("--num-records", type="int", default=1024)
+    parser.add_option("--inter-trial-wait", type="int", default=0)
+    parser.add_option("--unique-keys", type="int", default=1024)
+    parser.add_option("--key-length", type="int", default=10)
+    parser.add_option("--unique-values", type="int", default=102400)
+    parser.add_option("--value-length", type="int", default=20)
+    parser.add_option("--num-partitions", type="int", default=10)
+    parser.add_option("--random-seed", type="int", default=1)
+    parser.add_option("--persistent-type", default="memory")
+    parser.add_option("--storage-location", default="/tmp")
+    parser.add_option("--hash-records", action="store_true")
+    parser.add_option("--wait-for-exit", action="store_true")
+
+    options, cases = parser.parse_args()
+
+    sc = pyspark.SparkContext("local[*]", "TestRunner")
+    for name in cases:
+        test = globals()[name](sc)
+        test.initialize(options)
+        test.createInputData()
+        ts = test.run()
+        print "results:", ",".join("%.3f" % t for t in ts)


### PR DESCRIPTION
The test cases are copied from spark tests

Here is local tests results (scale=0.01):

python-scheduling-throughput, SchedulerThroughputTest --num-tasks=5000 --num-trials=4 --inter-trial-wait=1, 17.284, 0.627, 16.029, 17.284, 16.029
python-agg-by-key, AggregateByKey --num-trials=4 --inter-trial-wait=1 --num-partitions=4 --reduce-tasks=4 --random-seed=5 --persistent-type=memory  --num-records=2000000 --unique-keys=200 --key-length=10 --unique-values=10000 --value-length=10  --storage-location=/spark-perf-kv-data, 1.662, 0.011, 1.64, 1.640, 1.662
python-agg-by-key-int, AggregateByKeyInt --num-trials=4 --inter-trial-wait=1 --num-partitions=8 --reduce-tasks=8 --random-seed=5 --persistent-type=memory  --num-records=4000000 --unique-keys=400 --key-length=10 --unique-values=20000 --value-length=10  --storage-location=/spark-perf-kv-data, 1.428, 0.003, 1.421, 1.421, 1.428
python-agg-by-key-naive, AggregateByKeyNaive --num-trials=4 --inter-trial-wait=1 --num-partitions=4 --reduce-tasks=4 --random-seed=5 --persistent-type=memory  --num-records=2000000 --unique-keys=200 --key-length=10 --unique-values=10000 --value-length=10  --storage-location=/spark-perf-kv-data, 1.917, 0.008, 1.901, 1.917, 1.901
python-sort-by-key, SortByKey --num-trials=4 --inter-trial-wait=1 --num-partitions=1 --reduce-tasks=1 --random-seed=5 --persistent-type=memory  --num-records=200000 --unique-keys=20 --key-length=10 --unique-values=1000 --value-length=10  --storage-location=/spark-perf-kv-data, 0.751, 0.018, 0.716, 0.751, 0.716
python-sort-by-key-int, SortByKeyInt --num-trials=4 --inter-trial-wait=1 --num-partitions=1 --reduce-tasks=1 --random-seed=5 --persistent-type=memory  --num-records=400000 --unique-keys=40 --key-length=10 --unique-values=2000 --value-length=10  --storage-location=/spark-perf-kv-data, 1.295, 0.020, 1.254, 1.254, 1.295
python-count, Count --num-trials=4 --inter-trial-wait=1 --num-partitions=4 --reduce-tasks=4 --random-seed=5 --persistent-type=memory  --num-records=2000000 --unique-keys=200 --key-length=10 --unique-values=10000 --value-length=10  --storage-location=/spark-perf-kv-data, 0.337, 0.002, 0.334, 0.334, 0.337
python-count-w-fltr, CountWithFilter --num-trials=4 --inter-trial-wait=1 --num-partitions=4 --reduce-tasks=4 --random-seed=5 --persistent-type=memory  --num-records=2000000 --unique-keys=200 --key-length=10 --unique-values=10000 --value-length=10  --storage-location=/spark-perf-kv-data, 1.144, 0.013, 1.118, 1.118, 1.144
