### PR TITLE
do not reuse feature vector

### DIFF
--- a/mllib-tests/src/main/scala/mllib/perf/util/DataGenerator.scala
+++ b/mllib-tests/src/main/scala/mllib/perf/util/DataGenerator.scala
@@ -432,12 +432,11 @@ class FeaturesGenerator(val categoricalArities: Array[Int], val numContinuous: I
 
   private val rng = new java.util.Random()
 
-  private var arr = new Array[Double](numFeatures)
-
   /**
    * Generates vector with categorical features first, and continuous features in [0,1] second.
    */
   override def nextValue(): Vector = {
+    val arr = new Array[Double](numFeatures)
     // Feature ordering matches getCategoricalFeaturesInfo.
     var j = 0
     while (j < categoricalArities.size) {


### PR DESCRIPTION
If we re-use feature vector, cached RDD will contain identical records. @jkbradley @brkyvz
