### PR TITLE
Fixed that duplicated arr variable is defined as value in DataGenerator....

### DIFF
--- a/mllib-tests/onepointoh/src/main/scala/mllib/perf/onepointoh/util/DataGenerator.scala
+++ b/mllib-tests/onepointoh/src/main/scala/mllib/perf/onepointoh/util/DataGenerator.scala
@@ -440,7 +440,7 @@ class FeaturesGenerator(val categoricalArities: Array[Int], val numContinuous: I
    * Generates vector with categorical features first, and continuous features in [0,1] second.
    */
   override def nextValue(): Vector = {
-    val arr = new Array[Double](numFeatures)
+
     // Feature ordering matches getCategoricalFeaturesInfo.
     val arr = new Array[Double](numFeatures)
     var j = 0


### PR DESCRIPTION
Compile error and throws out since 'arr' variable is already defined as value in DataGenerator.scala
