### PR TITLE
Pyspark test fails: no such option: --storage-location

### DIFF
--- a/pyspark-tests/core_tests.py
+++ b/pyspark-tests/core_tests.py
@@ -160,6 +160,7 @@ if __name__ == "__main__":
     parser.add_option("--num-partitions", type="int", default=10)
     parser.add_option("--broadcast-size", type="int", default=1 << 20)
     parser.add_option("--random-seed", type="int", default=1)
+    parser.add_option("--storage-location", type="str", default="/")
     parser.add_option("--persistent-type", default="memory")
     parser.add_option("--wait-for-exit", action="store_true")
 


### PR DESCRIPTION
Performance test fails with a next error:
```
Running test command: 'core_tests.py' ...

Setting env var SPARK_SUBMIT_OPTS: -Dspark.storage.memoryFraction=0.66 -Dspark.serializer=org.apache.spark.serializer.JavaSerializer -Dspark.executor.memory=2g -Dspark.locality.wait=60000000 -Dsparkperf.commitSHA=unknown
Running command: /root/spark/bin/spark-submit --master spark://ubuntu-14:7077 pyspark-tests/core_tests.py AggregateByKey --num-trials=10 --inter-trial-wait=3 --num-partitions=1 --reduce-tasks=1 --random-seed=5 --persistent-type=memory  --num-records=200000 --unique-keys=20 --key-length=10 --unique-values=1000 --value-length=10  --storage-location=hdfs://ubuntu-14:9000/test//spark-perf-kv-data 1>> results/python_perf_output__2015-01-13_14-48-07_logs/python-agg-by-key.out 2>> results/python_perf_output__2015-01-13_14-48-07_logs/python-agg-by-key.err

Test did not produce expected results. Output was:
--------------------------------------------------------------------
Java options: -Dspark.storage.memoryFraction=0.66 -Dspark.serializer=org.apache.spark.serializer.JavaSerializer -Dspark.executor.memory=2g -Dspark.locality.wait=60000000
Options: AggregateByKey --num-trials=10 --inter-trial-wait=3 --num-partitions=1 --reduce-tasks=1 --random-seed=5 --persistent-type=memory  --num-records=200000 --unique-keys=20 --key-length=10 --unique-values=1000 --value-length=10  --storage-location=hdfs://ubuntu-14:9000/test//spark-perf-kv-data
--------------------------------------------------------------------
Usage: core_tests.py [options] test_names

core_tests.py: error: no such option: --storage-location
```