### PR TITLE
Protect against word splitting in dirname call

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-export PYTHONPATH="$(dirname $0)/../lib/:$PYTHONPATH"
-/usr/bin/env python "$(dirname $0)/../lib/sparkperf/main.py" "$@"
+export PYTHONPATH="$(dirname "$0")/../lib/:$PYTHONPATH"
+/usr/bin/env python "$(dirname "$0")/../lib/sparkperf/main.py" "$@"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-export PYTHONPATH="$(dirname $0)/lib/:$PYTHONPATH"
-nosetests --with-doctest -v "$(dirname $0)/lib/sparkperf"
+export PYTHONPATH="$(dirname "$0")/lib/:$PYTHONPATH"
+nosetests --with-doctest -v "$(dirname "$0")/lib/sparkperf"


### PR DESCRIPTION
If `$0` contains spaces, the call to `dirname` won't work as expected.