### PR TITLE
update the default num partitions for MLlib

### DIFF
--- a/config/config.py.template
+++ b/config/config.py.template
@@ -378,7 +378,8 @@ if MLLIB_SPARK_VERSION >= 1.1:
 # operations on MLlib algorithms.
 MLLIB_COMMON_OPTS = COMMON_OPTS + [
     # The number of input partitions.
-    OptionSet("num-partitions", [400], can_scale=True),
+    # The default setting is suitable for a 16-node m3.2xlarge EC2 cluster.
+    OptionSet("num-partitions", [128], can_scale=True),
     # A random seed to make tests reproducable.
     OptionSet("random-seed", [5])
 ]


### PR DESCRIPTION
ML algorithms works the best when the number of partitions matches the number of cores. So I change the default to 128 to match a 16-node m3.2xlarge EC2 cluster, which we used for perf tests.