### PR TITLE
copy MLlib v1p2 to v1p3

### DIFF
--- a/mllib-tests/project/MLlibTestsBuild.scala
+++ b/mllib-tests/project/MLlibTestsBuild.scala
@@ -36,6 +36,7 @@ object MLlibTestsBuild extends Build {
           case v if v.startsWith("1.0.") => "v1p0"
           case v if v.startsWith("1.1.") => "v1p1"
           case v if v.startsWith("1.2.") => "v1p2"
+          case v if v.startsWith("1.3.") => "v1p3"
           case _ => throw new IllegalArgumentException(s"Do not support Spark $sparkVersion.")
         }
         baseDirectory.value / targetFolder / "src"

--- a/mllib-tests/v1p3/project/plugins.sbt
+++ b/mllib-tests/v1p3/project/plugins.sbt
@@ -1,0 +1,1 @@
+logLevel := Level.Warn

--- a/mllib-tests/v1p3/src/main/scala/mllib/perf/LinearAlgebraTests.scala
+++ b/mllib-tests/v1p3/src/main/scala/mllib/perf/LinearAlgebraTests.scala
@@ -1,0 +1,68 @@
+package mllib.perf
+
+import org.json4s.JsonAST.JValue
+import org.json4s.JsonDSL._
+
+import org.apache.spark.SparkContext
+import org.apache.spark.mllib.linalg.distributed.RowMatrix
+
+import mllib.perf.util.DataGenerator
+
+/** Parent class for linear algebra tests which run on a large dataset.
+  * Generated this way so that SVD / PCA can be added easily
+  */
+abstract class LinearAlgebraTests(sc: SparkContext) extends PerfTest {
+
+  def runTest(rdd: RowMatrix, rank: Int)
+
+  val NUM_ROWS =  ("num-rows",   "number of rows of the matrix")
+  val NUM_COLS =  ("num-cols",   "number of columns of the matrix")
+  val RANK =  ("rank",   "number of leading singular values")
+
+  longOptions = Seq(NUM_ROWS)
+  intOptions = intOptions ++ Seq(RANK, NUM_COLS)
+
+  var rdd: RowMatrix = _
+
+  val options = intOptions ++ stringOptions  ++ booleanOptions ++ doubleOptions ++ longOptions
+  addOptionsToParser()
+  override def createInputData(seed: Long) = {
+    val m: Long = longOptionValue(NUM_ROWS)
+    val n: Int = intOptionValue(NUM_COLS)
+    val numPartitions: Int = intOptionValue(NUM_PARTITIONS)
+
+    rdd = DataGenerator.generateDistributedSquareMatrix(sc, m, n, numPartitions, seed)
+  }
+
+  override def run(): JValue = {
+    val rank = intOptionValue(RANK)
+
+    val start = System.currentTimeMillis()
+    runTest(rdd, rank)
+    val end = System.currentTimeMillis()
+    val time = (end - start).toDouble / 1000.0
+
+    Map("time" -> time)
+  }
+}
+
+
+class SVDTest(sc: SparkContext) extends LinearAlgebraTests(sc) {
+  override def runTest(data: RowMatrix, rank: Int) {
+     data.computeSVD(rank, computeU = true)
+  }
+}
+
+class PCATest(sc: SparkContext) extends LinearAlgebraTests(sc) {
+  override def runTest(data: RowMatrix, rank: Int) {
+    val principal = data.computePrincipalComponents(rank)
+    sc.broadcast(principal)
+    data.multiply(principal)
+  }
+}
+
+class ColumnSummaryStatisticsTest(sc: SparkContext) extends LinearAlgebraTests(sc) {
+  override def runTest(data: RowMatrix, rank: Int) {
+    data.computeColumnSummaryStatistics()
+  }
+}

--- a/mllib-tests/v1p3/src/main/scala/mllib/perf/MLAlgorithmTests.scala
+++ b/mllib-tests/v1p3/src/main/scala/mllib/perf/MLAlgorithmTests.scala
@@ -1,0 +1,591 @@
+package mllib.perf
+
+import org.json4s.JsonDSL._
+import org.json4s.JsonAST._
+
+import org.apache.spark.SparkContext
+import org.apache.spark.SparkContext._
+import org.apache.spark.mllib.classification._
+import org.apache.spark.mllib.clustering.{KMeansModel, KMeans}
+import org.apache.spark.mllib.linalg.{Vector, Vectors}
+import org.apache.spark.mllib.recommendation.{Rating, MatrixFactorizationModel, ALS}
+import org.apache.spark.mllib.regression._
+import org.apache.spark.mllib.tree.impurity.{Variance, Gini}
+import org.apache.spark.mllib.tree.RandomForest
+import org.apache.spark.mllib.tree.model.RandomForestModel
+import org.apache.spark.rdd.RDD
+
+import mllib.perf.util.{DataLoader, DataGenerator}
+
+/** Parent class for tests which run on a large dataset. */
+abstract class RegressionAndClassificationTests[M](sc: SparkContext) extends PerfTest {
+
+  def runTest(rdd: RDD[LabeledPoint]): M
+
+  def validate(model: M, rdd: RDD[LabeledPoint]): Double
+
+  val NUM_EXAMPLES =  ("num-examples",   "number of examples for regression tests")
+  val NUM_FEATURES =  ("num-features",   "number of features of each example for regression tests")
+
+  intOptions = intOptions ++ Seq(NUM_FEATURES)
+  longOptions = Seq(NUM_EXAMPLES)
+
+  var rdd: RDD[LabeledPoint] = _
+  var testRdd: RDD[LabeledPoint] = _
+
+  override def run(): JValue = {
+    var start = System.currentTimeMillis()
+    val model = runTest(rdd)
+    val trainingTime = (System.currentTimeMillis() - start).toDouble / 1000.0
+
+    start = System.currentTimeMillis()
+    val trainingMetric = validate(model, rdd)
+    val testTime = (System.currentTimeMillis() - start).toDouble / 1000.0
+
+    val testMetric = validate(model, testRdd)
+    Map("trainingTime" -> trainingTime, "testTime" -> testTime,
+      "trainingMetric" -> trainingMetric, "testMetric" -> testMetric)
+  }
+
+  /**
+   * For classification
+   * @param predictions RDD over (prediction, truth) for each instance
+   * @return Percent correctly classified
+   */
+  def calculateAccuracy(predictions: RDD[(Double, Double)], numExamples: Long): Double = {
+    predictions.map{case (pred, label) =>
+      if (pred == label) 1.0 else 0.0
+    }.sum() * 100.0 / numExamples
+  }
+
+  /**
+   * For regression
+   * @param predictions RDD over (prediction, truth) for each instance
+   * @return Root mean squared error (RMSE)
+   */
+  def calculateRMSE(predictions: RDD[(Double, Double)], numExamples: Long): Double = {
+    val error = predictions.map{ case (pred, label) =>
+      (pred - label) * (pred - label)
+    }.sum()
+    math.sqrt(error / numExamples)
+  }
+}
+
+/** Parent class for Generalized Linear Model (GLM) tests */
+abstract class GLMTests(sc: SparkContext)
+  extends RegressionAndClassificationTests[GeneralizedLinearModel](sc) {
+
+  val STEP_SIZE =      ("step-size",   "step size for SGD")
+  val NUM_ITERATIONS = ("num-iterations",   "number of iterations for the algorithm")
+  val REG_TYPE =       ("reg-type",   "type of regularization: none, l1, l2")
+  val REG_PARAM =      ("reg-param",   "the regularization parameter against overfitting")
+  val OPTIMIZER =      ("optimizer", "optimization algorithm: sgd, lbfgs")
+
+  intOptions = intOptions ++ Seq(NUM_ITERATIONS)
+  doubleOptions = doubleOptions ++ Seq(STEP_SIZE, REG_PARAM)
+  stringOptions = stringOptions ++ Seq(REG_TYPE, OPTIMIZER)
+}
+
+class GLMRegressionTest(sc: SparkContext) extends GLMTests(sc) {
+
+  val INTERCEPT =  ("intercept",   "intercept for random data generation")
+  val EPS =  ("epsilon",   "scale factor for the noise during data generation")
+  val LOSS =  ("loss",   "loss to minimize. Supported: l2 (squared error).")
+
+  doubleOptions = doubleOptions ++ Seq(INTERCEPT, EPS)
+  stringOptions = stringOptions ++ Seq(LOSS)
+
+  val options = intOptions ++ stringOptions  ++ booleanOptions ++ doubleOptions ++ longOptions
+  addOptionsToParser()
+
+  override def createInputData(seed: Long) = {
+    val numExamples: Long = longOptionValue(NUM_EXAMPLES)
+    val numFeatures: Int = intOptionValue(NUM_FEATURES)
+    val numPartitions: Int = intOptionValue(NUM_PARTITIONS)
+
+    val intercept: Double = doubleOptionValue(INTERCEPT)
+    val eps: Double = doubleOptionValue(EPS)
+
+    val data = DataGenerator.generateLabeledPoints(sc, math.ceil(numExamples * 1.25).toLong,
+      numFeatures, intercept, eps, numPartitions, seed)
+
+    val split = data.randomSplit(Array(0.8, 0.2), seed)
+
+    rdd = split(0).cache()
+    testRdd = split(1)
+
+    // Materialize rdd
+    println("Num Examples: " + rdd.count())
+  }
+
+  override def validate(model: GeneralizedLinearModel, rdd: RDD[LabeledPoint]): Double = {
+    val numExamples = rdd.count()
+    val predictions: RDD[(Double, Double)] = rdd.map { example =>
+      (model.predict(example.features), example.label)
+    }
+    calculateRMSE(predictions, numExamples)
+  }
+
+  override def runTest(rdd: RDD[LabeledPoint]): GeneralizedLinearModel = {
+    val stepSize = doubleOptionValue(STEP_SIZE)
+    val loss = stringOptionValue(LOSS)
+    val regType = stringOptionValue(REG_TYPE)
+    val regParam = doubleOptionValue(REG_PARAM)
+    val numIterations = intOptionValue(NUM_ITERATIONS)
+    val optimizer = stringOptionValue(OPTIMIZER)
+
+    if (!Array("l2").contains(loss)) {
+      throw new IllegalArgumentException(
+        s"GLMRegressionTest run with unknown loss ($loss).  Supported values: l2.")
+    }
+    if (!Array("none", "l1", "l2").contains(regType)) {
+      throw new IllegalArgumentException(
+        s"GLMRegressionTest run with unknown regType ($regType).  Supported values: none, l1, l2.")
+    }
+    if (!Array("sgd").contains(optimizer)) { // only SGD supported in Spark 1.1
+      throw new IllegalArgumentException(
+        s"GLMRegressionTest run with unknown optimizer ($optimizer). Supported values: sgd.")
+    }
+
+    (loss, regType) match {
+      case ("l2", "none") =>
+        val lr = new LinearRegressionWithSGD().setIntercept(addIntercept = true)
+        lr.optimizer.setNumIterations(numIterations).setStepSize(stepSize)
+        lr.run(rdd)
+      case ("l2", "l1") =>
+        val lasso = new LassoWithSGD().setIntercept(addIntercept = true)
+        lasso.optimizer.setNumIterations(numIterations).setStepSize(stepSize).setRegParam(regParam)
+        lasso.run(rdd)
+      case ("l2", "l2") =>
+        val rr = new RidgeRegressionWithSGD().setIntercept(addIntercept = true)
+        rr.optimizer.setNumIterations(numIterations).setStepSize(stepSize).setRegParam(regParam)
+        rr.run(rdd)
+    }
+  }
+}
+
+class GLMClassificationTest(sc: SparkContext) extends GLMTests(sc) {
+
+  val THRESHOLD =  ("per-negative",   "probability for a negative label during data generation")
+  val SCALE =  ("scale-factor",   "scale factor for the noise during data generation")
+  val LOSS =  ("loss",   "loss to minimize. Supported: logistic, hinge (SVM).")
+
+  doubleOptions = doubleOptions ++ Seq(THRESHOLD, SCALE)
+  stringOptions = stringOptions ++ Seq(LOSS)
+
+  val options = intOptions ++ stringOptions  ++ booleanOptions ++ doubleOptions ++ longOptions
+  addOptionsToParser()
+
+  override def validate(model: GeneralizedLinearModel, rdd: RDD[LabeledPoint]): Double = {
+    val numExamples = rdd.count()
+    val predictions: RDD[(Double, Double)] = rdd.map { example =>
+      (model.predict(example.features), example.label)
+    }
+    calculateAccuracy(predictions, numExamples)
+  }
+
+  override def createInputData(seed: Long) = {
+    val numExamples: Long = longOptionValue(NUM_EXAMPLES)
+    val numFeatures: Int = intOptionValue(NUM_FEATURES)
+    val numPartitions: Int = intOptionValue(NUM_PARTITIONS)
+
+    val threshold: Double = doubleOptionValue(THRESHOLD)
+    val sf: Double = doubleOptionValue(SCALE)
+
+    val data = DataGenerator.generateClassificationLabeledPoints(sc,
+      math.ceil(numExamples * 1.25).toLong, numFeatures, threshold, sf, numPartitions, seed)
+
+    val split = data.randomSplit(Array(0.8, 0.2), seed)
+
+    rdd = split(0).cache()
+    testRdd = split(1)
+
+    // Materialize rdd
+    println("Num Examples: " + rdd.count())
+  }
+
+  override def runTest(rdd: RDD[LabeledPoint]): GeneralizedLinearModel = {
+    val stepSize = doubleOptionValue(STEP_SIZE)
+    val loss = stringOptionValue(LOSS)
+    val regType = stringOptionValue(REG_TYPE)
+    val regParam = doubleOptionValue(REG_PARAM)
+    val numIterations = intOptionValue(NUM_ITERATIONS)
+    val optimizer = stringOptionValue(OPTIMIZER)
+
+    if (!Array("logistic", "hinge").contains(loss)) {
+      throw new IllegalArgumentException(
+        s"GLMClassificationTest run with unknown loss ($loss).  Supported values: logistic, hinge.")
+    }
+    if (!Array("none", "l1", "l2").contains(regType)) {
+      throw new IllegalArgumentException(s"GLMClassificationTest run with unknown regType" +
+        s" ($regType).  Supported values: none, l1, l2.")
+    }
+    if (!Array("sgd", "lbfgs").contains(optimizer)) {
+      throw new IllegalArgumentException(
+        s"GLMRegressionTest run with unknown optimizer ($optimizer). Supported values: sgd, lbfgs.")
+    }
+
+    (loss, regType, optimizer) match {
+      case ("logistic", "none", "sgd") =>
+        LogisticRegressionWithSGD.train(rdd, numIterations, stepSize)
+      case ("logistic", "none", "lbfgs") =>
+        println("WARNING: LogisticRegressionWithLBFGS ignores numIterations, stepSize" +
+          " in this Spark version.")
+        new LogisticRegressionWithLBFGS().run(rdd)
+      case ("hinge", "l2", "sgd") =>
+        SVMWithSGD.train(rdd, numIterations, stepSize, regParam)
+      case _ =>
+        throw new IllegalArgumentException(
+          s"GLMClassificationTest given incompatible (loss, regType) = ($loss, $regType)." +
+            s" Note the set of supported combinations increases in later Spark versions.")
+    }
+  }
+}
+
+abstract class RecommendationTests(sc: SparkContext) extends PerfTest {
+
+  def runTest(rdd: RDD[Rating]): MatrixFactorizationModel
+
+  val NUM_USERS =    ("num-users",   "number of users for recommendation tests")
+  val NUM_PRODUCTS = ("num-products", "number of features of each example for recommendation tests")
+  val NUM_RATINGS =  ("num-ratings",   "number of ratings for recommendation tests")
+  val RANK =         ("rank", "rank of factorized matrices for recommendation tests")
+  val IMPLICIT =     ("implicit-prefs", "use implicit ratings")
+  val NUM_ITERATIONS =  ("num-iterations",   "number of iterations for the algorithm")
+  val REG_PARAM =      ("reg-param",   "the regularization parameter against overfitting")
+
+  intOptions = intOptions ++ Seq(NUM_USERS, NUM_PRODUCTS, RANK, NUM_ITERATIONS)
+  longOptions = longOptions ++ Seq(NUM_RATINGS)
+  booleanOptions = booleanOptions ++ Seq(IMPLICIT)
+  doubleOptions = doubleOptions ++ Seq(REG_PARAM)
+  val options = intOptions ++ stringOptions  ++ booleanOptions ++ longOptions ++ doubleOptions
+  addOptionsToParser()
+
+  var rdd: RDD[Rating] = _
+  var testRdd: RDD[Rating] = _
+
+  override def createInputData(seed: Long) = {
+    val numPartitions: Int = intOptionValue(NUM_PARTITIONS)
+
+    val numUsers: Int = intOptionValue(NUM_USERS)
+    val numProducts: Int = intOptionValue(NUM_PRODUCTS)
+    val numRatings: Long = longOptionValue(NUM_RATINGS)
+    val implicitRatings: Boolean = booleanOptionValue(IMPLICIT)
+
+    val data = DataGenerator.generateRatings(sc, numUsers, numProducts,
+      math.ceil(numRatings * 1.25).toLong, implicitRatings,numPartitions,seed)
+
+    rdd = data._1.cache()
+    testRdd = data._2
+
+    // Materialize rdd
+    println("Num Examples: " + rdd.count())
+
+  }
+
+  def validate(model: MatrixFactorizationModel,
+               data: RDD[Rating]): Double = {
+    val implicitPrefs: Boolean = booleanOptionValue(IMPLICIT)
+    val predictions: RDD[Rating] = model.predict(data.map(x => (x.user, x.product)))
+    val predictionsAndRatings: RDD[(Double, Double)] = predictions.map{ x =>
+      def mapPredictedRating(r: Double) = if (implicitPrefs) math.max(math.min(r, 1.0), 0.0) else r
+      ((x.user, x.product), mapPredictedRating(x.rating))
+    }.join(data.map(x => ((x.user, x.product), x.rating))).values
+
+    math.sqrt(predictionsAndRatings.map(x => (x._1 - x._2) * (x._1 - x._2)).mean())
+  }
+
+  override def run(): JValue = {
+    var start = System.currentTimeMillis()
+    val model = runTest(rdd)
+    val trainingTime = (System.currentTimeMillis() - start).toDouble / 1000.0
+
+    start = System.currentTimeMillis()
+    val trainingMetric = validate(model, rdd)
+    val testTime = (System.currentTimeMillis() - start).toDouble / 1000.0
+
+    val testMetric = validate(model, testRdd)
+    Map("trainingTime" -> trainingTime, "testTime" -> testTime,
+      "trainingMetric" -> trainingMetric, "testMetric" -> testMetric)
+  }
+}
+
+abstract class ClusteringTests(sc: SparkContext) extends PerfTest {
+
+  def runTest(rdd: RDD[Vector]): KMeansModel
+
+  val NUM_POINTS =    ("num-points",   "number of points for clustering tests")
+  val NUM_COLUMNS =   ("num-columns",   "number of columns for each point for clustering tests")
+  val NUM_CENTERS =   ("num-centers",   "number of centers for clustering tests")
+  val NUM_ITERATIONS =      ("num-iterations",   "number of iterations for the algorithm")
+
+  intOptions = intOptions ++ Seq(NUM_CENTERS, NUM_COLUMNS, NUM_ITERATIONS)
+  longOptions = longOptions ++ Seq(NUM_POINTS)
+  val options = intOptions ++ stringOptions  ++ booleanOptions ++ longOptions ++ doubleOptions
+  addOptionsToParser()
+
+  var rdd: RDD[Vector] = _
+  var testRdd: RDD[Vector] = _
+
+  def validate(model: KMeansModel, rdd: RDD[Vector]): Double = {
+    val numPoints = rdd.cache().count()
+
+    val error = model.computeCost(rdd)
+
+    math.sqrt(error/numPoints)
+  }
+
+  override def createInputData(seed: Long) = {
+    val numPartitions: Int = intOptionValue(NUM_PARTITIONS)
+
+    val numPoints: Long = longOptionValue(NUM_POINTS)
+    val numColumns: Int = intOptionValue(NUM_COLUMNS)
+    val numCenters: Int = intOptionValue(NUM_CENTERS)
+
+    val data = DataGenerator.generateKMeansVectors(sc, math.ceil(numPoints*1.25).toLong, numColumns,
+      numCenters, numPartitions, seed)
+
+    val split = data.randomSplit(Array(0.8, 0.2), seed)
+
+    rdd = split(0).cache()
+    testRdd = split(1)
+
+    // Materialize rdd
+    println("Num Examples: " + rdd.count())
+  }
+
+  override def run(): JValue = {
+    var start = System.currentTimeMillis()
+    val model = runTest(rdd)
+    val trainingTime = (System.currentTimeMillis() - start).toDouble / 1000.0
+
+    start = System.currentTimeMillis()
+    val trainingMetric = validate(model, rdd)
+    val testTime = (System.currentTimeMillis() - start).toDouble / 1000.0
+
+    val testMetric = validate(model, testRdd)
+    Map("trainingTime" -> trainingTime, "testTime" -> testTime,
+      "trainingMetric" -> trainingMetric, "testMetric" -> testMetric)
+  }
+}
+
+// Classification Algorithms
+
+class NaiveBayesTest(sc: SparkContext)
+  extends RegressionAndClassificationTests[NaiveBayesModel](sc) {
+
+  val THRESHOLD =  ("per-negative",   "probability for a negative label during data generation")
+  val SCALE =  ("scale-factor",   "scale factor for the noise during data generation")
+  val SMOOTHING =     ("nb-lambda",   "the smoothing parameter lambda for Naive Bayes")
+
+  doubleOptions = doubleOptions ++ Seq(THRESHOLD, SCALE, SMOOTHING)
+
+  val options = intOptions ++ stringOptions  ++ booleanOptions ++ doubleOptions ++ longOptions
+  addOptionsToParser()
+
+  /** Note: using same data generation as for GLMClassificationTest, but should change later */
+  override def createInputData(seed: Long) = {
+    val numExamples: Long = longOptionValue(NUM_EXAMPLES)
+    val numFeatures: Int = intOptionValue(NUM_FEATURES)
+    val numPartitions: Int = intOptionValue(NUM_PARTITIONS)
+
+    val threshold: Double = doubleOptionValue(THRESHOLD)
+    val sf: Double = doubleOptionValue(SCALE)
+
+    val data = DataGenerator.generateClassificationLabeledPoints(sc,
+      math.ceil(numExamples * 1.25).toLong, numFeatures, threshold, sf, numPartitions, seed)
+    val dataNonneg = data.map { lp =>
+      LabeledPoint(lp.label, Vectors.dense(lp.features.toArray.map(math.abs)))
+    }
+
+    val split = dataNonneg.randomSplit(Array(0.8, 0.2), seed)
+
+    rdd = split(0).cache()
+    testRdd = split(1)
+
+    // Materialize rdd
+    println("Num Examples: " + rdd.count())
+  }
+
+  override def validate(model: NaiveBayesModel, rdd: RDD[LabeledPoint]): Double = {
+    val numExamples = rdd.count()
+    val predictions: RDD[(Double, Double)] = rdd.map { example =>
+      (model.predict(example.features), example.label)
+    }
+    calculateAccuracy(predictions, numExamples)
+  }
+
+  override def runTest(rdd: RDD[LabeledPoint]): NaiveBayesModel = {
+    val lambda = doubleOptionValue(SMOOTHING)
+    NaiveBayes.train(rdd, lambda)
+  }
+}
+
+// Recommendation
+class ALSTest(sc: SparkContext) extends RecommendationTests(sc) {
+  override def runTest(rdd: RDD[Rating]): MatrixFactorizationModel = {
+    val numIterations: Int = intOptionValue(NUM_ITERATIONS)
+    val rank: Int = intOptionValue(RANK)
+    val regParam = doubleOptionValue(REG_PARAM)
+    val seed = intOptionValue(RANDOM_SEED) + 12
+
+    new ALS().setIterations(numIterations).setRank(rank).setSeed(seed).setLambda(regParam)
+      .setBlocks(rdd.partitions.size).run(rdd)
+  }
+}
+
+// Clustering
+class KMeansTest(sc: SparkContext) extends ClusteringTests(sc) {
+  override def runTest(rdd: RDD[Vector]): KMeansModel = {
+    val numIterations: Int = intOptionValue(NUM_ITERATIONS)
+    val k: Int = intOptionValue(NUM_CENTERS)
+    KMeans.train(rdd, k, numIterations)
+  }
+}
+
+/**
+ * Parent class for DecisionTree-based tests which run on a large dataset.
+ */
+abstract class DecisionTreeTests(sc: SparkContext)
+  extends RegressionAndClassificationTests[RandomForestModel](sc) {
+
+  val TEST_DATA_FRACTION =
+    ("test-data-fraction",  "fraction of data to hold out for testing (ignored if given training and test dataset)")
+  val LABEL_TYPE =
+    ("label-type", "Type of label: 0 indicates regression, 2+ indicates " +
+      "classification with this many classes")
+  val FRAC_CATEGORICAL_FEATURES = ("frac-categorical-features",
+    "Fraction of features which are categorical")
+  val FRAC_BINARY_FEATURES =
+    ("frac-binary-features", "Fraction of categorical features which are binary. " +
+      "Others have 20 categories.")
+  val TREE_DEPTH = ("tree-depth", "Depth of true decision tree model used to label examples.")
+  val MAX_BINS = ("max-bins", "Maximum number of bins for the decision tree learning algorithm.")
+  val NUM_TREES = ("num-trees", "Number of trees to train.  If 1, run DecisionTree.  If >1, run an ensemble method (RandomForest).")
+  val FEATURE_SUBSET_STRATEGY =
+    ("feature-subset-strategy", "Strategy for feature subset sampling. Supported: auto, all, sqrt, log2, onethird.")
+
+  intOptions = intOptions ++ Seq(LABEL_TYPE, TREE_DEPTH, MAX_BINS, NUM_TREES)
+  doubleOptions = doubleOptions ++ Seq(TEST_DATA_FRACTION, FRAC_CATEGORICAL_FEATURES, FRAC_BINARY_FEATURES)
+  stringOptions = stringOptions ++ Seq(FEATURE_SUBSET_STRATEGY)
+
+  addOptionalOptionToParser("training-data", "path to training dataset (if not given, use random data)", "", classOf[String])
+  addOptionalOptionToParser("test-data", "path to test dataset (only used if training dataset given)" +
+      " (if not given, hold out part of training data for validation)", "", classOf[String])
+
+  var categoricalFeaturesInfo: Map[Int, Int] = Map.empty
+
+  protected var labelType = -1
+
+  def validate(model: RandomForestModel, rdd: RDD[LabeledPoint]): Double = {
+    val numExamples = rdd.count()
+    val predictions: RDD[(Double, Double)] = rdd.map { example =>
+      (model.predict(example.features), example.label)
+    }
+    val labelType: Int = intOptionValue(LABEL_TYPE)
+    if (labelType == 0) {
+      calculateRMSE(predictions, numExamples)
+    } else {
+      calculateAccuracy(predictions, numExamples)
+    }
+  }
+}
+
+class DecisionTreeTest(sc: SparkContext) extends DecisionTreeTests(sc) {
+
+  val ENSEMBLE_TYPE = ("ensemble-type", "Type of ensemble algorithm: RandomForest.")
+
+  stringOptions = stringOptions ++ Seq(ENSEMBLE_TYPE)
+
+  val options = intOptions ++ stringOptions ++ booleanOptions ++ doubleOptions ++ longOptions
+  addOptionsToParser()
+
+  private def getTestDataFraction: Double = {
+    val testDataFraction: Double = doubleOptionValue(TEST_DATA_FRACTION)
+    assert(testDataFraction >= 0 && testDataFraction <= 1, s"Bad testDataFraction: $testDataFraction")
+    testDataFraction
+  }
+
+  override def createInputData(seed: Long) = {
+    val trainingDataPath: String = optionValue[String]("training-data")
+    val (rdds, categoricalFeaturesInfo_, numClasses) = if (trainingDataPath != "") {
+      println(s"LOADING FILE: $trainingDataPath")
+      val numPartitions: Int = intOptionValue(NUM_PARTITIONS)
+      val testDataPath: String = optionValue[String]("test-data")
+      val testDataFraction: Double = getTestDataFraction
+      DataLoader.loadLibSVMFiles(sc, numPartitions, trainingDataPath, testDataPath,
+        testDataFraction, seed)
+    } else {
+      createSyntheticInputData(seed)
+    }
+    assert(rdds.length == 2)
+    rdd = rdds(0).cache()
+    testRdd = rdds(1)
+    categoricalFeaturesInfo = categoricalFeaturesInfo_
+    this.labelType = numClasses
+
+    // Materialize rdd
+    println("Num Examples: " + rdd.count())
+  }
+
+  /**
+   * Create synthetic training and test datasets.
+   * @return (trainTestDatasets, categoricalFeaturesInfo, numClasses) where
+   *          trainTestDatasets = Array(trainingData, testData),
+   *          categoricalFeaturesInfo is a map of categorical feature arities, and
+   *          numClasses = number of classes label can take.
+   */
+  private def createSyntheticInputData(
+      seed: Long): (Array[RDD[LabeledPoint]], Map[Int, Int], Int) = {
+    // Generic test options
+    val numPartitions: Int = intOptionValue(NUM_PARTITIONS)
+    val testDataFraction: Double = getTestDataFraction
+    // Data dimensions and type
+    val numExamples: Long = longOptionValue(NUM_EXAMPLES)
+    val numFeatures: Int = intOptionValue(NUM_FEATURES)
+    val labelType: Int = intOptionValue(LABEL_TYPE)
+    val fracCategoricalFeatures: Double = doubleOptionValue(FRAC_CATEGORICAL_FEATURES)
+    val fracBinaryFeatures: Double = doubleOptionValue(FRAC_BINARY_FEATURES)
+    // Model specification
+    val treeDepth: Int = intOptionValue(TREE_DEPTH)
+
+    val (rdd_, categoricalFeaturesInfo_) =
+      DataGenerator.generateDecisionTreeLabeledPoints(sc, math.ceil(numExamples * 1.25).toLong,
+        numFeatures, numPartitions, labelType,
+        fracCategoricalFeatures, fracBinaryFeatures, treeDepth, seed)
+
+    val splits = rdd_.randomSplit(Array(1.0 - testDataFraction, testDataFraction), seed)
+    (splits, categoricalFeaturesInfo_, labelType)
+  }
+
+  override def runTest(rdd: RDD[LabeledPoint]): RandomForestModel = {
+    val treeDepth: Int = intOptionValue(TREE_DEPTH)
+    val maxBins: Int = intOptionValue(MAX_BINS)
+    val numTrees: Int = intOptionValue(NUM_TREES)
+    val featureSubsetStrategy: String = stringOptionValue(FEATURE_SUBSET_STRATEGY)
+    val ensembleType: String = stringOptionValue(ENSEMBLE_TYPE)
+    if (!Array("RandomForest").contains(ensembleType)) {
+      throw new IllegalArgumentException(
+        s"DecisionTreeTest given unknown ensembleType param: $ensembleType." +
+        " Supported values: RandomForest.")
+    }
+    if (labelType == 0) {
+      // Regression
+      ensembleType match {
+        case "RandomForest" =>
+          RandomForest.trainRegressor(rdd, categoricalFeaturesInfo, numTrees, featureSubsetStrategy,
+            "variance", treeDepth, maxBins, this.getRandomSeed)
+      }
+    } else if (labelType >= 2) {
+      // Classification
+      ensembleType match {
+        case "RandomForest" =>
+          RandomForest.trainClassifier(rdd, labelType, categoricalFeaturesInfo, numTrees,
+            featureSubsetStrategy, "gini", treeDepth, maxBins, this.getRandomSeed)
+      }
+    } else {
+      throw new IllegalArgumentException(s"Bad label-type parameter " +
+        s"given to DecisionTreeTest: $labelType")
+    }
+  }
+}

--- a/mllib-tests/v1p3/src/main/scala/mllib/perf/PerfTest.scala
+++ b/mllib-tests/v1p3/src/main/scala/mllib/perf/PerfTest.scala
@@ -1,0 +1,127 @@
+package mllib.perf
+
+import scala.collection.JavaConverters._
+
+import joptsimple.{OptionSet, OptionParser}
+
+import org.json4s._
+
+import org.apache.spark.Logging
+
+abstract class PerfTest extends Logging {
+
+  val NUM_TRIALS =          ("num-trials",    "number of trials to run")
+  val INTER_TRIAL_WAIT =    ("inter-trial-wait",   "seconds to sleep between trials")
+  val NUM_PARTITIONS =      ("num-partitions", "number of input partitions")
+  val RANDOM_SEED =         ("random-seed", "seed for random number generator")
+
+  /** Initialize internal state based on arguments */
+  def initialize(testName_ : String, otherArgs: Array[String]) {
+    testName = testName_
+    optionSet = parser.parse(otherArgs:_*)
+  }
+
+  def getRandomSeed: Int = {
+    intOptionValue(RANDOM_SEED)
+  }
+
+  def getNumTrials: Int = {
+    intOptionValue(NUM_TRIALS)
+  }
+
+  def getWait: Int = {
+    intOptionValue(INTER_TRIAL_WAIT) * 1000
+  }
+
+  def createInputData(seed: Long)
+
+  /**
+   * Runs the test and returns a JSON object that captures performance metrics, such as time taken,
+   * and values of any parameters.
+   *
+   * The rendered JSON will look like this (except it will be minified):
+   *
+   *    {
+   *       "options": {
+   *         "num-partitions": "10",
+   *         "unique-values": "10",
+   *         ...
+   *       },
+   *       "results": [
+   *         {
+   *           "trainingTime": 0.211,
+   *           "trainingMetric": 98.1,
+   *           ...
+   *         },
+   *         ...
+   *       ]
+   *     }
+   *
+   * @return metrics from run (e.g. ("time" -> time)
+   *  */
+  def run(): JValue
+
+  val parser = new OptionParser()
+  var optionSet: OptionSet = _
+  var testName: String = _
+
+  var intOptions: Seq[(String, String)] = Seq(NUM_TRIALS, INTER_TRIAL_WAIT, NUM_PARTITIONS,
+    RANDOM_SEED)
+
+  var doubleOptions: Seq[(String, String)] = Seq()
+  var longOptions: Seq[(String, String)] = Seq()
+
+  var stringOptions: Seq[(String, String)] = Seq()
+  var booleanOptions: Seq[(String, String)] = Seq()
+
+  def addOptionsToParser() {
+    // add all the options to parser
+    stringOptions.map{case (opt, desc) =>
+      parser.accepts(opt, desc).withRequiredArg().ofType(classOf[String]).required()
+    }
+    booleanOptions.map{case (opt, desc) =>
+      parser.accepts(opt, desc)
+    }
+    intOptions.map{case (opt, desc) =>
+      parser.accepts(opt, desc).withRequiredArg().ofType(classOf[Int]).required()
+    }
+    doubleOptions.map{case (opt, desc) =>
+      parser.accepts(opt, desc).withRequiredArg().ofType(classOf[Double]).required()
+    }
+    longOptions.map{case (opt, desc) =>
+      parser.accepts(opt, desc).withRequiredArg().ofType(classOf[Long]).required()
+    }
+  }
+
+  def addOptionalOptionToParser[T](opt: String, desc: String, default: T, clazz: Class[T]): Unit = {
+    parser.accepts(opt, desc).withOptionalArg().ofType(clazz).defaultsTo(default)
+  }
+
+  def intOptionValue(option: (String, String)) =
+    optionSet.valueOf(option._1).asInstanceOf[Int]
+
+  def stringOptionValue(option: (String, String)) =
+    optionSet.valueOf(option._1).asInstanceOf[String]
+
+  def booleanOptionValue(option: (String, String)) =
+    optionSet.has(option._1)
+
+  def doubleOptionValue(option: (String, String)) =
+    optionSet.valueOf(option._1).asInstanceOf[Double]
+
+  def longOptionValue(option: (String, String)) =
+    optionSet.valueOf(option._1).asInstanceOf[Long]
+
+  def optionValue[T](option: String) =
+    optionSet.valueOf(option).asInstanceOf[T]
+
+  def getOptions: Map[String, String] = {
+    optionSet.asMap().asScala.flatMap { case (spec, values) =>
+      if (spec.options().size() == 1 && values.size() == 1) {
+        Some((spec.options().iterator().next(), values.iterator().next().toString))
+      } else {
+        None
+      }
+    }.toMap
+  }
+}

--- a/mllib-tests/v1p3/src/main/scala/mllib/perf/StatTests.scala
+++ b/mllib-tests/v1p3/src/main/scala/mllib/perf/StatTests.scala
@@ -1,0 +1,109 @@
+package mllib.perf
+
+import org.json4s.JsonDSL._
+import org.json4s.JsonAST._
+
+import scala.util.Random
+
+import org.apache.spark.mllib.linalg.{Matrices, Vectors, Matrix, Vector}
+import org.apache.spark.SparkContext
+import org.apache.spark.mllib.random.RandomRDDs
+import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.mllib.stat.Statistics
+import org.apache.spark.rdd.RDD
+
+import mllib.perf.util.DataGenerator
+
+
+/**
+ * Parent class for the tests for the statistics toolbox
+ */
+abstract class StatTests[T](sc: SparkContext) extends PerfTest {
+
+  def runTest(rdd: T)
+
+  val NUM_ROWS =  ("num-rows",   "number of rows of the matrix")
+  val NUM_COLS =  ("num-cols",   "number of columns of the matrix")
+
+  longOptions = Seq(NUM_ROWS)
+  intOptions = intOptions ++ Seq(NUM_COLS)
+
+  var rdd: T = _
+
+  val options = intOptions ++ stringOptions  ++ booleanOptions ++ doubleOptions ++ longOptions
+  addOptionsToParser()
+
+  override def run(): JValue = {
+    val start = System.currentTimeMillis()
+    runTest(rdd)
+    val end = System.currentTimeMillis()
+    val time = (end - start).toDouble / 1000.0
+    Map("time" -> time)
+  }
+}
+
+abstract class CorrelationTests(sc: SparkContext) extends StatTests[RDD[Vector]](sc){
+  override def createInputData(seed: Long) = {
+    val m: Long = longOptionValue(NUM_ROWS)
+    val n: Int = intOptionValue(NUM_COLS)
+    val numPartitions: Int = intOptionValue(NUM_PARTITIONS)
+
+    rdd = RandomRDDs.normalVectorRDD(sc, m, n, numPartitions, seed).cache()
+
+    // Materialize rdd
+    println("Num Examples: " + rdd.count())
+  }
+}
+
+class PearsonCorrelationTest(sc: SparkContext) extends CorrelationTests(sc) {
+  override def runTest(data: RDD[Vector]) {
+     Statistics.corr(data)
+  }
+}
+
+class SpearmanCorrelationTest(sc: SparkContext) extends CorrelationTests(sc) {
+  override def runTest(data: RDD[Vector]) {
+    Statistics.corr(data, "spearman")
+  }
+}
+
+class ChiSquaredFeatureTest(sc: SparkContext) extends StatTests[RDD[LabeledPoint]](sc) {
+  override def createInputData(seed: Long) = {
+    val m: Long = longOptionValue(NUM_ROWS)
+    val n: Int = intOptionValue(NUM_COLS)
+    val numPartitions: Int = intOptionValue(NUM_PARTITIONS)
+
+    rdd = DataGenerator.generateClassificationLabeledPoints(sc, m, n, 0.5, 1.0, numPartitions,
+      seed, chiSq = true).cache()
+
+    // Materialize rdd
+    println("Num Examples: " + rdd.count())
+  }
+  override def runTest(data: RDD[LabeledPoint]) {
+    Statistics.chiSqTest(data)
+  }
+}
+
+class ChiSquaredGoFTest(sc: SparkContext) extends StatTests[Vector](sc) {
+  override def createInputData(seed: Long) = {
+    val m: Long = longOptionValue(NUM_ROWS)
+    val rng = new Random(seed)
+
+    rdd = Vectors.dense(Array.fill(m.toInt)(rng.nextDouble()))
+  }
+  override def runTest(data: Vector) {
+    Statistics.chiSqTest(data)
+  }
+}
+
+class ChiSquaredMatTest(sc: SparkContext) extends StatTests[Matrix](sc) {
+  override def createInputData(seed: Long) = {
+    val m: Long = longOptionValue(NUM_ROWS)
+    val rng = new Random(seed)
+
+    rdd = Matrices.dense(m.toInt, m.toInt, Array.fill(m.toInt * m.toInt)(rng.nextDouble()))
+  }
+  override def runTest(data: Matrix) {
+    Statistics.chiSqTest(data)
+  }
+}

--- a/mllib-tests/v1p3/src/main/scala/mllib/perf/TestRunner.scala
+++ b/mllib-tests/v1p3/src/main/scala/mllib/perf/TestRunner.scala
@@ -1,0 +1,74 @@
+package mllib.perf
+
+import scala.collection.JavaConverters._
+
+import org.json4s.JsonDSL._
+import org.json4s.JsonAST._
+import org.json4s.jackson.JsonMethods._
+
+import org.apache.spark.SparkConf
+import org.apache.spark.SparkContext
+
+object TestRunner {
+    def main(args: Array[String]) {
+      if (args.size < 1) {
+        println(
+          "mllib.perf.TestRunner requires 1 or more args, you gave %s, exiting".format(args.size))
+        System.exit(1)
+      }
+      val testName = args(0)
+      val perfTestArgs = args.slice(1, args.length)
+      val sc = new SparkContext(new SparkConf().setAppName("TestRunner: " + testName))
+
+      // Unfortunate copy of code because there are Perf Tests in both projects and the compiler doesn't like it
+      val test: PerfTest = testName match {
+        case "glm-regression" => new GLMRegressionTest(sc)
+        case "glm-classification" => new GLMClassificationTest(sc)
+        case "naive-bayes" => new NaiveBayesTest(sc)
+        // recommendation
+        case "als" => new ALSTest(sc)
+        // clustering
+        case "kmeans" => new KMeansTest(sc)
+        // trees
+        case "decision-tree" => new DecisionTreeTest(sc)
+        // linalg
+        case "svd" => new SVDTest(sc)
+        case "pca" => new PCATest(sc)
+        // stats
+        case "summary-statistics" => new ColumnSummaryStatisticsTest(sc)
+        case "pearson" => new PearsonCorrelationTest(sc)
+        case "spearman" => new SpearmanCorrelationTest(sc)
+        case "chi-sq-feature" => new ChiSquaredFeatureTest(sc)
+        case "chi-sq-gof" => new ChiSquaredGoFTest(sc)
+        case "chi-sq-mat" => new ChiSquaredMatTest(sc)
+      }
+      test.initialize(testName, perfTestArgs)
+      // Generate a new dataset for each test
+      val rand = new java.util.Random(test.getRandomSeed)
+
+      val numTrials = test.getNumTrials
+      val interTrialWait = test.getWait
+
+      var testOptions: JValue = test.getOptions
+      val results: Seq[JValue] = (1 to numTrials).map { i =>
+        test.createInputData(rand.nextLong())
+        val res: JValue = test.run()
+        System.gc()
+        Thread.sleep(interTrialWait)
+        res
+      }
+      // Report the test results as a JSON object describing the test options, Spark
+      // configuration, Java system properties, as well as the per-test results.
+      // This extra information helps to ensure reproducibility and makes automatic analysis easier.
+      val json: JValue =
+        ("testName" -> testName) ~
+        ("options" -> testOptions) ~
+        ("sparkConf" -> sc.getConf.getAll.toMap) ~
+        ("sparkVersion" -> sc.version) ~
+        ("systemProperties" -> System.getProperties.asScala.toMap) ~
+        ("results" -> results)
+      println("results: " + compact(render(json)))
+
+      sc.stop()
+  }
+}

--- a/mllib-tests/v1p3/src/main/scala/mllib/perf/util/DataGenerator.scala
+++ b/mllib-tests/v1p3/src/main/scala/mllib/perf/util/DataGenerator.scala
@@ -1,0 +1,512 @@
+package mllib.perf.util
+
+import scala.collection.mutable
+
+import org.apache.spark.mllib.linalg.{Vectors, Vector}
+import org.apache.spark.mllib.linalg.distributed.RowMatrix
+import org.apache.spark.mllib.random._
+import org.apache.spark.mllib.recommendation.Rating
+import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.mllib.tree.configuration.{Algo, FeatureType}
+import org.apache.spark.mllib.tree.model.{Split, DecisionTreeModel, Node, Predict}
+import org.apache.spark.rdd.{PairRDDFunctions, RDD}
+import org.apache.spark.SparkContext
+
+object DataGenerator {
+
+  def generateLabeledPoints(
+      sc: SparkContext,
+      numRows: Long,
+      numCols: Int,
+      intercept: Double,
+      eps: Double,
+      numPartitions: Int,
+      seed: Long = System.currentTimeMillis(),
+      problem: String = ""): RDD[LabeledPoint] = {
+
+    RandomRDDs.randomRDD(sc,
+      new LinearDataGenerator(numCols,intercept, seed, eps, problem), numRows, numPartitions, seed)
+
+  }
+
+  def generateDistributedSquareMatrix(
+      sc: SparkContext,
+      m: Long,
+      n: Int,
+      numPartitions: Int,
+      seed: Long = System.currentTimeMillis()): RowMatrix = {
+
+    val data: RDD[Vector] = RandomRDDs.normalVectorRDD(sc, m, n, numPartitions, seed)
+
+    new RowMatrix(data,m,n)
+  }
+
+  def generateClassificationLabeledPoints(
+      sc: SparkContext,
+      numRows: Long,
+      numCols: Int,
+      threshold: Double,
+      scaleFactor: Double,
+      numPartitions: Int,
+      seed: Long = System.currentTimeMillis(),
+      chiSq: Boolean = false): RDD[LabeledPoint] = {
+
+    RandomRDDs.randomRDD(sc, new ClassLabelGenerator(numCols,threshold, scaleFactor, chiSq),
+      numRows, numPartitions, seed)
+  }
+
+  /**
+   * @param labelType  0 = regression with labels in [0,1].  Values >= 2 indicate classification.
+   * @param fracCategorical  Fraction of columns/features to be categorical.
+   * @param fracBinary   Fraction of categorical features to be binary.  Others are high-arity (20).
+   * @param treeDepth  Depth of "true" tree used to label points.
+   * @return (data, categoricalFeaturesInfo)
+   *         data is an RDD of data points.
+   *         categoricalFeaturesInfo is a map storing the arity of categorical features.
+   *         E.g., an entry (n -> k) indicates that feature n is categorical
+   *         with k categories indexed from 0: {0, 1, ..., k-1}.
+   */
+  def generateDecisionTreeLabeledPoints(
+      sc: SparkContext,
+      numRows: Long,
+      numCols: Int,
+      numPartitions: Int,
+      labelType: Int,
+      fracCategorical: Double,
+      fracBinary: Double,
+      treeDepth: Int,
+      seed: Long = System.currentTimeMillis()): (RDD[LabeledPoint], Map[Int, Int]) = {
+
+    val highArity = 20
+
+    require(fracCategorical >= 0 && fracCategorical <= 1,
+      s"fracCategorical must be in [0,1], but it is $fracCategorical")
+    require(fracBinary >= 0 && fracBinary <= 1,
+      s"fracBinary must be in [0,1], but it is $fracBinary")
+
+    val isRegression = labelType == 0
+    if (!isRegression) {
+      require(labelType >= 2, s"labelType must be >= 2 for classification. 0 indicates regression.")
+    }
+    val numCategorical = (numCols * fracCategorical).toInt
+    val numContinuous = numCols - numCategorical
+    val numBinary = (numCategorical * fracBinary).toInt
+    val numHighArity = numCategorical - numBinary
+    val categoricalArities = Array.concat(Array.fill(numBinary)(2),
+      Array.fill(numHighArity)(highArity))
+
+    val featuresGenerator = new FeaturesGenerator(categoricalArities, numContinuous)
+    val featureMatrix = RandomRDDs.randomRDD(sc, featuresGenerator,
+      numRows, numPartitions, seed)
+
+    // Create random DecisionTree.
+    val featureArity = Array.concat(categoricalArities, Array.fill(numContinuous)(0))
+    val trueModel = randomBalancedDecisionTree(treeDepth, labelType, featureArity, seed)
+    println(trueModel)
+
+    // Label points using tree.
+    val labelVector = featureMatrix.map(trueModel.predict)
+
+    val data = labelVector.zip(featureMatrix).map(pair => new LabeledPoint(pair._1, pair._2))
+    val categoricalFeaturesInfo = featuresGenerator.getCategoricalFeaturesInfo
+    (data, categoricalFeaturesInfo)
+  }
+
+
+  def randomBalancedDecisionTree(
+      depth: Int,
+      labelType: Int,
+      featureArity: Array[Int],
+      seed: Long = System.currentTimeMillis()): DecisionTreeModel = {
+
+    require(depth >= 0, s"randomBalancedDecisionTree given depth < 0.")
+    require(depth <= featureArity.size,
+      s"randomBalancedDecisionTree requires depth <= featureArity.size," +
+      s" but depth = $depth and featureArity.size = ${featureArity.size}")
+    val isRegression = labelType == 0
+    if (!isRegression) {
+      require(labelType >= 2, s"labelType must be >= 2 for classification. 0 indicates regression.")
+    }
+
+    val rng = new scala.util.Random()
+    rng.setSeed(seed)
+
+    val labelGenerator = if (isRegression) {
+      new RealLabelPairGenerator()
+    } else {
+      new ClassLabelPairGenerator(labelType)
+    }
+
+    val topNode = randomBalancedDecisionTreeHelper(0, depth, featureArity, labelGenerator,
+      Set.empty, rng)
+    if (isRegression) {
+      new DecisionTreeModel(topNode, Algo.Regression)
+    } else {
+      new DecisionTreeModel(topNode, Algo.Classification)
+    }
+  }
+
+  /**
+   * Create an internal node.  Either create the leaf nodes beneath it, or recurse as needed.
+   * @param nodeIndex  Index of node.
+   * @param subtreeDepth  Depth of subtree to build.  Depth 0 means this is a leaf node.
+   * @param featureArity  Indicates feature type.  Value 0 indicates continuous feature.
+   *                      Other values >= 2 indicate a categorical feature,
+   *                      where the value is the number of categories.
+   * @param usedFeatures  Features appearing in the path from the tree root to the node
+   *                      being constructed.
+   * @param labelGenerator  Generates pairs of distinct labels.
+   * @return
+   */
+  def randomBalancedDecisionTreeHelper(
+      nodeIndex: Int,
+      subtreeDepth: Int,
+      featureArity: Array[Int],
+      labelGenerator: RandomDataGenerator[Pair[Double, Double]],
+      usedFeatures: Set[Int],
+      rng: scala.util.Random): Node = {
+
+    if (subtreeDepth == 0) {
+      // This case only happens for a depth 0 tree.
+      return new Node(id = nodeIndex, predict = new Predict(0), impurity = 0, isLeaf = true,
+        split = None, leftNode = None, rightNode = None, stats = None)
+    }
+
+    val numFeatures = featureArity.size
+    if (usedFeatures.size >= numFeatures) {
+      // Should not happen.
+      throw new RuntimeException(s"randomBalancedDecisionTreeSplitNode ran out of " +
+        s"features for splits.")
+    }
+
+    // Make node internal.
+    var feature: Int = rng.nextInt(numFeatures)
+    while (usedFeatures.contains(feature)) {
+      feature = rng.nextInt(numFeatures)
+    }
+    val split: Split = if (featureArity(feature) == 0) {
+      // continuous feature
+      new Split(feature = feature, threshold = rng.nextDouble(),
+        featureType = FeatureType.Continuous, categories = List())
+    } else {
+      // categorical feature
+      // Put nCatsSplit categories on left, and the rest on the right.
+      // nCatsSplit is in {1,...,arity-1}.
+      val nCatsSplit = rng.nextInt(featureArity(feature) - 1) + 1
+      val splitCategories = rng.shuffle(Range(0,featureArity(feature)).toList).take(nCatsSplit)
+      new Split(feature = feature, threshold = 0,
+        featureType = FeatureType.Categorical, categories =
+          splitCategories.asInstanceOf[List[Double]])
+    }
+
+    val leftChildIndex = nodeIndex * 2 + 1
+    val rightChildIndex = nodeIndex * 2 + 2
+    if (subtreeDepth == 1) {
+      // Add leaf nodes.
+      val predictions = labelGenerator.nextValue()
+      new Node(id = nodeIndex, predict = new Predict(0), impurity = 0, isLeaf = false, split = Some(split),
+        leftNode = Some(new Node(id = leftChildIndex, predict = new Predict(predictions._1), impurity = 0, isLeaf = true,
+          split = None, leftNode = None, rightNode = None, stats = None)),
+        rightNode = Some(new Node(id = rightChildIndex, predict = new Predict(predictions._2), impurity = 0, isLeaf = true,
+          split = None, leftNode = None, rightNode = None, stats = None)), stats = None)
+    } else {
+      new Node(id = nodeIndex, predict = new Predict(0), impurity = 0, isLeaf = false, split = Some(split),
+        leftNode = Some(randomBalancedDecisionTreeHelper(leftChildIndex, subtreeDepth - 1,
+          featureArity, labelGenerator, usedFeatures + feature, rng)),
+        rightNode = Some(randomBalancedDecisionTreeHelper(rightChildIndex, subtreeDepth - 1,
+          featureArity, labelGenerator, usedFeatures + feature, rng)), stats = None)
+    }
+  }
+
+  def generateKMeansVectors(
+      sc: SparkContext,
+      numRows: Long,
+      numCols: Int,
+      numCenters: Int,
+      numPartitions: Int,
+      seed: Long = System.currentTimeMillis()): RDD[Vector] = {
+
+    RandomRDDs.randomRDD(sc, new KMeansDataGenerator(numCenters, numCols, seed),
+      numRows, numPartitions, seed)
+  }
+
+
+  // Problems with having a userID or productID in the test set but not training set
+  // leads to a lot of work...
+  def generateRatings(
+      sc: SparkContext,
+      numUsers: Int,
+      numProducts: Int,
+      numRatings: Long,
+      implicitPrefs: Boolean,
+      numPartitions: Int,
+      seed: Long = System.currentTimeMillis()): (RDD[Rating],RDD[Rating]) = {
+
+    val train = RandomRDDs.randomRDD(sc,
+      new RatingGenerator(numUsers, numProducts,implicitPrefs),
+      numRatings, numPartitions, seed).cache()
+
+    val test = RandomRDDs.randomRDD(sc,
+      new RatingGenerator(numUsers, numProducts,implicitPrefs),
+      math.ceil(numRatings * 0.25).toLong, numPartitions, seed + 24)
+
+    // Now get rid of duplicate ratings and remove non-existant userID's
+    // and prodID's from the test set
+    val commons: PairRDDFunctions[(Int,Int),Rating] =
+      new PairRDDFunctions(train.keyBy(rating => (rating.user, rating.product)).cache())
+
+    val exact = commons.join(test.keyBy(rating => (rating.user, rating.product)))
+
+    val trainPruned = commons.subtractByKey(exact).map(_._2).cache()
+
+    // Now get rid of users that don't exist in the train set
+    val trainUsers: RDD[(Int,Rating)] = trainPruned.keyBy(rating => rating.user)
+    val testUsers: PairRDDFunctions[Int,Rating] =
+      new PairRDDFunctions(test.keyBy(rating => rating.user))
+    val testWithAdditionalUsers = testUsers.subtractByKey(trainUsers)
+
+    val userPrunedTestProds: RDD[(Int,Rating)] =
+      testUsers.subtractByKey(testWithAdditionalUsers).map(_._2).keyBy(rating => rating.product)
+
+    val trainProds: RDD[(Int,Rating)] = trainPruned.keyBy(rating => rating.product)
+
+    val testWithAdditionalProds =
+      new PairRDDFunctions[Int, Rating](userPrunedTestProds).subtractByKey(trainProds)
+    val finalTest =
+      new PairRDDFunctions[Int, Rating](userPrunedTestProds).subtractByKey(testWithAdditionalProds)
+        .map(_._2)
+
+    (trainPruned, finalTest)
+  }
+
+}
+
+class RatingGenerator(
+    private val numUsers: Int,
+    private val numProducts: Int,
+    private val implicitPrefs: Boolean) extends RandomDataGenerator[Rating] {
+
+  private val rng = new java.util.Random()
+
+  private val observed = new mutable.HashMap[(Int, Int), Boolean]()
+
+  override def nextValue(): Rating = {
+    var tuple = (rng.nextInt(numUsers),rng.nextInt(numProducts))
+    while (observed.getOrElse(tuple,false)){
+      tuple = (rng.nextInt(numUsers),rng.nextInt(numProducts))
+    }
+    observed += (tuple -> true)
+
+    val rating = if (implicitPrefs) rng.nextInt(2)*1.0 else rng.nextDouble()*5
+
+    new Rating(tuple._1, tuple._2, rating)
+  }
+
+  override def setSeed(seed: Long) {
+    rng.setSeed(seed)
+  }
+
+  override def copy(): RatingGenerator = new RatingGenerator(numUsers, numProducts, implicitPrefs)
+}
+
+// For general classification
+class ClassLabelGenerator(
+    private val numFeatures: Int,
+    private val threshold: Double,
+    private val scaleFactor: Double,
+    private val chiSq: Boolean) extends RandomDataGenerator[LabeledPoint] {
+
+  private val rng = new java.util.Random()
+
+  override def nextValue(): LabeledPoint = {
+    val y = if (rng.nextDouble() < threshold) 0.0 else 1.0
+    val x = Array.fill[Double](numFeatures) {
+      if (!chiSq) rng.nextGaussian() + (y * scaleFactor) else rng.nextInt(6) * 1.0
+    }
+
+    LabeledPoint(y, Vectors.dense(x))
+  }
+
+  override def setSeed(seed: Long) {
+    rng.setSeed(seed)
+  }
+
+  override def copy(): ClassLabelGenerator =
+    new ClassLabelGenerator(numFeatures, threshold, scaleFactor, chiSq)
+}
+
+class LinearDataGenerator(
+    val numFeatures: Int,
+    val intercept: Double,
+    val seed: Long,
+    val eps: Double,
+    val problem: String = "",
+    val sparsity: Double = 1.0) extends RandomDataGenerator[LabeledPoint] {
+
+  private val rng = new java.util.Random(seed)
+
+  private val weights = Array.fill(numFeatures)(rng.nextDouble())
+  private val nnz: Int = math.ceil(numFeatures*sparsity).toInt
+
+  override def nextValue(): LabeledPoint = {
+    val x = Array.fill[Double](nnz)(2*rng.nextDouble()-1)
+
+    val y = weights.zip(x).map(p => p._1 * p._2).sum + intercept + eps*rng.nextGaussian()
+    val yD =
+      if (problem == "SVM"){
+        if (y < 0.0) 0.0 else 1.0
+      } else{
+        y
+      }
+
+    LabeledPoint(yD, Vectors.dense(x))
+  }
+
+  override def setSeed(seed: Long) {
+    rng.setSeed(seed)
+  }
+
+  override def copy(): LinearDataGenerator =
+    new LinearDataGenerator(numFeatures, intercept, seed, eps, problem, sparsity)
+}
+
+
+/**
+ * Generator for a pair of distinct class labels from the set {0,...,numClasses-1}.
+ * @param numClasses  Number of classes.
+ */
+class ClassLabelPairGenerator(val numClasses: Int)
+  extends RandomDataGenerator[Pair[Double, Double]] {
+
+  require(numClasses >= 2,
+    s"ClassLabelPairGenerator given label numClasses = $numClasses, but numClasses should be >= 2.")
+
+  private val rng = new java.util.Random()
+
+  override def nextValue(): Pair[Double, Double] = {
+    val left = rng.nextInt(numClasses)
+    var right = rng.nextInt(numClasses)
+    while (right == left) {
+      right = rng.nextInt(numClasses)
+    }
+    new Pair[Double, Double](left, right)
+  }
+
+  override def setSeed(seed: Long) {
+    rng.setSeed(seed)
+  }
+
+  override def copy(): ClassLabelPairGenerator = new ClassLabelPairGenerator(numClasses)
+}
+
+
+/**
+ * Generator for a pair of real-valued labels.
+ */
+class RealLabelPairGenerator() extends RandomDataGenerator[Pair[Double, Double]] {
+
+  private val rng = new java.util.Random()
+
+  override def nextValue(): Pair[Double, Double] =
+    new Pair[Double, Double](rng.nextDouble(), rng.nextDouble())
+
+  override def setSeed(seed: Long) {
+    rng.setSeed(seed)
+  }
+
+  override def copy(): RealLabelPairGenerator = new RealLabelPairGenerator()
+}
+
+
+/**
+ * Generator for a feature vector which can include a mix of categorical and continuous features.
+ * @param categoricalArities  Specifies the number of categories for each categorical feature.
+ * @param numContinuous  Number of continuous features.  Feature values are in range [0,1].
+ */
+class FeaturesGenerator(val categoricalArities: Array[Int], val numContinuous: Int)
+  extends RandomDataGenerator[Vector] {
+
+  categoricalArities.foreach { arity =>
+    require(arity >= 2, s"FeaturesGenerator given categorical arity = $arity, " +
+      s"but arity should be >= 2.")
+  }
+
+  val numFeatures = categoricalArities.size + numContinuous
+
+  private val rng = new java.util.Random()
+
+  /**
+   * Generates vector with categorical features first, and continuous features in [0,1] second.
+   */
+  override def nextValue(): Vector = {
+    // Feature ordering matches getCategoricalFeaturesInfo.
+    val arr = new Array[Double](numFeatures)
+    var j = 0
+    while (j < categoricalArities.size) {
+      arr(j) = rng.nextInt(categoricalArities(j))
+      j += 1
+    }
+    while (j < numFeatures) {
+      arr(j) = rng.nextDouble()
+      j += 1
+    }
+    Vectors.dense(arr)
+  }
+
+  override def setSeed(seed: Long) {
+    rng.setSeed(seed)
+  }
+
+  override def copy(): FeaturesGenerator = new FeaturesGenerator(categoricalArities, numContinuous)
+
+  /**
+   * @return categoricalFeaturesInfo Map storing arity of categorical features.
+   *                                 E.g., an entry (n -> k) indicates that feature n is categorical
+   *                                 with k categories indexed from 0: {0, 1, ..., k-1}.
+   */
+  def getCategoricalFeaturesInfo: Map[Int, Int] = {
+    // Categorical features are indexed from 0 because of the implementation of nextValue().
+    categoricalArities.zipWithIndex.map(_.swap).toMap
+  }
+
+}
+
+
+class KMeansDataGenerator(
+    val numCenters: Int,
+    val numColumns: Int,
+    val seed: Long) extends RandomDataGenerator[Vector] {
+
+  private val rng = new java.util.Random(seed)
+  private val rng2 = new java.util.Random(seed + 24)
+  private val scale_factors = Array.fill(numCenters)(rng.nextInt(20) - 10)
+
+  // Have a random number of points around a cluster
+  private val concentrations: Seq[Double] = {
+    val rand = Array.fill(numCenters)(rng.nextDouble())
+    val randSum = rand.sum
+    val scaled = rand.map(x => x / randSum)
+
+    (1 to numCenters).map{i =>
+      scaled.slice(0, i).sum
+    }
+  }
+
+  private val centers = (0 until numCenters).map{i =>
+    Array.fill(numColumns)((2 * rng.nextDouble() - 1)*scale_factors(i))
+  }
+
+  override def nextValue(): Vector = {
+    val pick_center_rand = rng2.nextDouble()
+
+    val centerToAddTo = centers(concentrations.indexWhere(p => pick_center_rand <= p))
+
+    Vectors.dense(Array.tabulate(numColumns)(i => centerToAddTo(i) + rng2.nextGaussian()))
+  }
+
+  override def setSeed(seed: Long) {
+    rng.setSeed(seed)
+  }
+
+  override def copy(): KMeansDataGenerator = new KMeansDataGenerator(numCenters, numColumns, seed)
+}

--- a/mllib-tests/v1p3/src/main/scala/mllib/perf/util/DataLoader.scala
+++ b/mllib-tests/v1p3/src/main/scala/mllib/perf/util/DataLoader.scala
@@ -1,0 +1,143 @@
+package mllib.perf.util
+
+import org.apache.spark.SparkContext
+import org.apache.spark.mllib.regression._
+import org.apache.spark.mllib.util.MLUtils
+import org.apache.spark.rdd.RDD
+
+object DataLoader {
+
+  // For DecisionTreeTest: PartitionLabelStats tracks the stats for each partition.
+  class PartitionLabelStats(
+      var min: Double,
+      var max: Double,
+      var distinct: Long,
+      var nonInteger: Boolean)
+    extends Serializable
+
+  object PartitionLabelStats extends Serializable {
+    /** Max categories allowed for categorical label (for inferring labelType) */
+    val MAX_CATEGORIES = 1000
+
+    def labelSeqOp(lps: Iterator[LabeledPoint]): Iterator[PartitionLabelStats] = {
+      val stats = new PartitionLabelStats(Double.MaxValue, Double.MinValue, 0, false)
+      val labelSet = new scala.collection.mutable.HashSet[Double]()
+      lps.foreach { lp =>
+        if (lp.label.toInt != lp.label) {
+          stats.nonInteger = true
+        }
+        stats.min = Math.min(lp.label, stats.min)
+        stats.max = Math.max(lp.label, stats.max)
+        if (labelSet.size <= MAX_CATEGORIES) {
+          labelSet.add(lp.label)
+        }
+      }
+      stats.distinct = labelSet.size
+      Iterator(stats)
+      Iterator(new PartitionLabelStats(0,0,0,false))
+    }
+
+    def labelCombOp(
+        labelStatsA: PartitionLabelStats,
+        labelStatsB: PartitionLabelStats): PartitionLabelStats = {
+      labelStatsA.min = Math.min(labelStatsA.min, labelStatsB.min)
+      labelStatsA.max = Math.max(labelStatsA.max, labelStatsB.max)
+      labelStatsA.distinct = Math.max(labelStatsB.distinct, labelStatsB.distinct)
+      labelStatsA
+    }
+  }
+
+  /** Infer label type from data */
+  private def isClassification(data: RDD[LabeledPoint]): Boolean = {
+    val labelStats =
+      data.mapPartitions(PartitionLabelStats.labelSeqOp)
+        .fold(new PartitionLabelStats(Double.MaxValue, Double.MinValue, 0, false))(
+          PartitionLabelStats.labelCombOp)
+    labelStats.distinct <= PartitionLabelStats.MAX_CATEGORIES && !labelStats.nonInteger
+  }
+
+  /**
+   * Load training and test LibSVM-format data files.
+   * @return (trainTestDatasets, categoricalFeaturesInfo, numClasses) where
+   *         trainTestDatasets = Array(trainingData, testData),
+   *         categoricalFeaturesInfo is a map of categorical feature arities, and
+   *         numClasses = number of classes label can take.
+   */
+  private[perf] def loadLibSVMFiles(
+      sc: SparkContext,
+      numPartitions: Int,
+      trainingDataPath: String,
+      testDataPath: String,
+      testDataFraction: Double,
+      seed: Long): (Array[RDD[LabeledPoint]], Map[Int, Int], Int) = {
+
+    val trainingData = MLUtils.loadLibSVMFile(sc, trainingDataPath, -1, numPartitions)
+
+    val (rdds, categoricalFeaturesInfo_) = if (testDataPath == "") {
+      // randomly split trainingData into train, test
+      val splits = trainingData.randomSplit(Array(1.0 - testDataFraction, testDataFraction), seed)
+      (splits, Map.empty[Int, Int])
+    } else {
+      // load test data
+      val numFeatures = trainingData.take(1)(0).features.size
+      val testData = MLUtils.loadLibSVMFile(sc, testDataPath, numFeatures, numPartitions)
+      (Array(trainingData, testData), Map.empty[Int, Int])
+    }
+
+    // For classification, re-index classes if needed.
+    val (finalDatasets, classIndexMap, numClasses) = {
+      if (isClassification(rdds(0)) && isClassification(rdds(1))) {
+        // classCounts: class --> # examples in class
+        val classCounts: Map[Double, Long] = {
+          val trainClassCounts = rdds(0).map(_.label).countByValue()
+          val testClassCounts = rdds(1).map(_.label).countByValue()
+          val mutableClassCounts = new scala.collection.mutable.HashMap[Double, Long]()
+          trainClassCounts.foreach { case (label, cnt) =>
+            mutableClassCounts(label) = mutableClassCounts.getOrElseUpdate(label, 0) + cnt
+          }
+          testClassCounts.foreach { case (label, cnt) =>
+            mutableClassCounts(label) = mutableClassCounts.getOrElseUpdate(label, 0) + cnt
+          }
+          mutableClassCounts.toMap
+        }
+        val sortedClasses = classCounts.keys.toList.sorted
+        val numClasses = classCounts.size
+        // classIndexMap: class --> index in 0,...,numClasses-1
+        val classIndexMap = {
+          if (classCounts.keySet != Set(0.0, 1.0)) {
+            sortedClasses.zipWithIndex.toMap
+          } else {
+            Map[Double, Int]()
+          }
+        }
+        val indexedRdds = {
+          if (classIndexMap.isEmpty) {
+            rdds
+          } else {
+            rdds.map { rdd =>
+              rdd.map(lp => LabeledPoint(classIndexMap(lp.label), lp.features))
+            }
+          }
+        }
+        val numTrain = indexedRdds(0).count()
+        val numTest = indexedRdds(1).count()
+        val numTotalInstances = numTrain + numTest
+        println(s"numTrain: $numTrain")
+        println(s"numTest: $numTest")
+        println(s"numClasses: $numClasses")
+        println(s"Per-class example fractions, counts:")
+        println(s"Class\tFrac\tCount")
+        sortedClasses.foreach { c =>
+          val frac = classCounts(c) / numTotalInstances.toDouble
+          println(s"$c\t$frac\t${classCounts(c)}")
+        }
+        (indexedRdds, classIndexMap, numClasses)
+      } else {
+        (rdds, null, 0)
+      }
+    }
+
+    (finalDatasets, categoricalFeaturesInfo_, numClasses)
+  }
+
+}


### PR DESCRIPTION
This PR copies `v1p2/` to `v1p3` without any code change. We may want to consider a better approach to deal with new algorithms and experimental API changes in the future.