### PR TITLE
Update MLlib test default settings

### DIFF
--- a/config/config.py.template
+++ b/config/config.py.template
@@ -400,7 +400,7 @@ MLLIB_GLM_TEST_OPTS = MLLIB_REGRESSION_CLASSIFICATION_TEST_OPTS + [
     # The number of iterations for SGD
     OptionSet("num-iterations", [20]),
     # The step size for SGD
-    OptionSet("step-size", [0.05]),
+    OptionSet("step-size", [0.001]),
     # Regularization type: none, l1, l2
     OptionSet("reg-type", ["l2"]),
     # Regularization parameter

--- a/config/config.py.template
+++ b/config/config.py.template
@@ -390,9 +390,9 @@ MLLIB_COMMON_OPTS = COMMON_OPTS + [
 # Regression and Classification Tests #
 MLLIB_REGRESSION_CLASSIFICATION_TEST_OPTS = MLLIB_COMMON_OPTS + [
     # The number of rows or examples
-    OptionSet("num-examples", [1000000], can_scale=True),
+    OptionSet("num-examples", [2000000], can_scale=True),
     # The number of features per example
-    OptionSet("num-features", [10000], can_scale=True)
+    OptionSet("num-features", [10000], can_scale=False)
 ]
 
 # Generalized Linear Model (GLM) Tests #
@@ -461,7 +461,7 @@ MLLIB_DECISION_TREE_TEST_OPTS = MLLIB_COMMON_OPTS + [
     # The number of rows or examples
     OptionSet("num-examples", [1000000], can_scale=True),
     # The number of features per example
-    OptionSet("num-features", [500], can_scale=True),
+    OptionSet("num-features", [500], can_scale=False),
     # Type of label: 0 indicates regression, 2+ indicates classification with this many classes
     # Note: multi-class (>2) is not supported in Spark 1.0.
     OptionSet("label-type", [0, 2], can_scale=False),
@@ -472,7 +472,7 @@ MLLIB_DECISION_TREE_TEST_OPTS = MLLIB_COMMON_OPTS + [
     # Depth of true decision tree model used to label examples.
     # WARNING: The meaning of depth changed from Spark 1.0 to Spark 1.1:
     #          depth=N for Spark 1.0 should be depth=N-1 for Spark 1.1
-    OptionSet("tree-depth", [1, 10], can_scale=False),
+    OptionSet("tree-depth", [4, 10], can_scale=False),
     # Maximum number of bins for the decision tree learning algorithm.
     OptionSet("max-bins", [32], can_scale=False),
 ]
@@ -504,7 +504,7 @@ MLLIB_RECOMMENDATION_TEST_OPTS = MLLIB_COMMON_OPTS + [
      # The number of users
      OptionSet("num-users", [6000000], can_scale=True),
      # The number of products
-     OptionSet("num-products", [5000000], can_scale=True),
+     OptionSet("num-products", [5000000], can_scale=False),
      # The number of ratings
      OptionSet("num-ratings", [50000000], can_scale=True),
      # The number of iterations for ALS
@@ -526,7 +526,7 @@ MLLIB_CLUSTERING_TEST_OPTS = MLLIB_COMMON_OPTS + [
      # The number of points
      OptionSet("num-points", [1000000], can_scale=True),
      # The number of features per point
-     OptionSet("num-columns", [10000], can_scale=True),
+     OptionSet("num-columns", [10000], can_scale=False),
      # The number of centers
      OptionSet("num-centers", [20]),
      # The number of iterations for KMeans
@@ -541,18 +541,18 @@ MLLIB_LINALG_TEST_OPTS = MLLIB_COMMON_OPTS + [
     # The number of rows for the matrix
     OptionSet("num-rows", [1000000], can_scale=True),
     # The number of columns for the matrix
-    OptionSet("num-cols", [1000], can_scale=True),
+    OptionSet("num-cols", [1000], can_scale=False),
     # The number of top singular values wanted for SVD and PCA
-    OptionSet("rank", [50], can_scale=True)
+    OptionSet("rank", [50], can_scale=False)
 ]
 # Linear Algebra Tests which take more time (slightly smaller settings) #
 MLLIB_BIG_LINALG_TEST_OPTS = MLLIB_COMMON_OPTS + [
     # The number of rows for the matrix
-    OptionSet("num-rows", [800000], can_scale=True),
+    OptionSet("num-rows", [1000000], can_scale=True),
     # The number of columns for the matrix
-    OptionSet("num-cols", [800], can_scale=True),
+    OptionSet("num-cols", [500], can_scale=False),
     # The number of top singular values wanted for SVD and PCA
-    OptionSet("rank", [40], can_scale=True)
+    OptionSet("rank", [20], can_scale=False)
 ]
 
 MLLIB_TESTS += [("svd", MLLIB_PERF_TEST_RUNNER, SCALE_FACTOR,
@@ -569,24 +569,24 @@ MLLIB_TESTS += [("summary-statistics", MLLIB_PERF_TEST_RUNNER, SCALE_FACTOR,
 MLLIB_STATS_TEST_OPTS = MLLIB_COMMON_OPTS
 
 MLLIB_PEARSON_TEST_OPTS = MLLIB_STATS_TEST_OPTS + \
-                          [OptionSet("num-rows", [10000000], can_scale=True),
-                           OptionSet("num-cols", [1000], can_scale=True)]
+                          [OptionSet("num-rows", [1000000], can_scale=True),
+                           OptionSet("num-cols", [1000], can_scale=False)]
 
 MLLIB_SPEARMAN_TEST_OPTS = MLLIB_STATS_TEST_OPTS + \
-                           [OptionSet("num-rows", [5000000], can_scale=True),
-                            OptionSet("num-cols", [100], can_scale=True)]
+                           [OptionSet("num-rows", [1000000], can_scale=True),
+                            OptionSet("num-cols", [100], can_scale=False)]
 
 MLLIB_CHI_SQ_FEATURE_TEST_OPTS = MLLIB_STATS_TEST_OPTS + \
-                                 [OptionSet("num-rows", [10000000], can_scale=True),
-                                  OptionSet("num-cols", [500], can_scale=True)]
+                                 [OptionSet("num-rows", [2000000], can_scale=True),
+                                  OptionSet("num-cols", [500], can_scale=False)]
 
 MLLIB_CHI_SQ_GOF_TEST_OPTS = MLLIB_STATS_TEST_OPTS + \
                              [OptionSet("num-rows", [50000000], can_scale=True),
-                              OptionSet("num-cols", [0], can_scale=True)]
+                              OptionSet("num-cols", [0], can_scale=False)]
 
 MLLIB_CHI_SQ_MAT_TEST_OPTS = MLLIB_STATS_TEST_OPTS + \
                              [OptionSet("num-rows", [20000], can_scale=True),
-                              OptionSet("num-cols", [0], can_scale=True)]
+                              OptionSet("num-cols", [0], can_scale=False)]
 
 if MLLIB_SPARK_VERSION >= 1.1:
     MLLIB_TESTS += [("pearson", MLLIB_PERF_TEST_RUNNER, SCALE_FACTOR,

--- a/config/config.py.template
+++ b/config/config.py.template
@@ -390,7 +390,7 @@ MLLIB_COMMON_OPTS = COMMON_OPTS + [
 # Regression and Classification Tests #
 MLLIB_REGRESSION_CLASSIFICATION_TEST_OPTS = MLLIB_COMMON_OPTS + [
     # The number of rows or examples
-    OptionSet("num-examples", [2000000], can_scale=True),
+    OptionSet("num-examples", [1000000], can_scale=True),
     # The number of features per example
     OptionSet("num-features", [10000], can_scale=False)
 ]
@@ -472,7 +472,7 @@ MLLIB_DECISION_TREE_TEST_OPTS = MLLIB_COMMON_OPTS + [
     # Depth of true decision tree model used to label examples.
     # WARNING: The meaning of depth changed from Spark 1.0 to Spark 1.1:
     #          depth=N for Spark 1.0 should be depth=N-1 for Spark 1.1
-    OptionSet("tree-depth", [4, 10], can_scale=False),
+    OptionSet("tree-depth", [5, 10], can_scale=False),
     # Maximum number of bins for the decision tree learning algorithm.
     OptionSet("max-bins", [32], can_scale=False),
 ]
@@ -552,7 +552,7 @@ MLLIB_BIG_LINALG_TEST_OPTS = MLLIB_COMMON_OPTS + [
     # The number of columns for the matrix
     OptionSet("num-cols", [500], can_scale=False),
     # The number of top singular values wanted for SVD and PCA
-    OptionSet("rank", [20], can_scale=False)
+    OptionSet("rank", [10], can_scale=False)
 ]
 
 MLLIB_TESTS += [("svd", MLLIB_PERF_TEST_RUNNER, SCALE_FACTOR,
@@ -624,7 +624,7 @@ if MLLIB_SPARK_VERSION >= 1.3:  # TODO: make it work in 1.2
 MLLIB_FPM_TEST_OPTS = MLLIB_COMMON_OPTS
 
 MLLIB_FP_GROWTH_TEST_OPTS = MLLIB_FPM_TEST_OPTS + \
-                            [OptionSet("num-baskets", [10000000], can_scale=True),
+                            [OptionSet("num-baskets", [5000000], can_scale=True),
                              OptionSet("avg-basket-size", [10], can_scale=False),
                              OptionSet("num-items", [1000], can_scale=False),
                              OptionSet("min-support", [0.01], can_scale=False)]


### PR DESCRIPTION
With the new defaults, each test should take 20-60s to finish, which gives us a more reliable metric to detect regression. I also changed the scaling setting to make sure the total cost scales linearly with the scale factor. Otherwise, it is very likely one test takes hours to finish at scale 5.0.