### PR TITLE
cache .m2 and .ivy2 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ jdk:
   - openjdk7
 before_install:
   - sudo pip install nose
+cache:
+  directories:
+  - $HOME/.m2
+  - $HOME/.ivy2
 script:
   - ./run-tests.sh
   - cd spark-tests


### PR DESCRIPTION
@JoshRosen @nchammas I've seen many build failures caused by fetching jars. We can cache the local maven and ivy repos to help this issue.