### PR TITLE
Fix Hadoop version at 1.2.1 when making a Spark distribution

### DIFF
--- a/bin/spark-ec2/install-maven
+++ b/bin/spark-ec2/install-maven
@@ -2,8 +2,8 @@
 
 # Script for installing Maven on spark-ec2 clusters
 
-MVN_VERSION=3.2.5
-MVN_MD5=b2d88f02bd3a08a9df1f0b0126ebd8dc
+MVN_VERSION=3.3.3
+MVN_MD5=794b3b7961200c542a7292682d21ba36
 
 # wget http://www.apache.org/dyn/closer.cgi/maven/maven-3/$MVN_VERSION/binaries/apache-maven-$MVN_VERSION-bin.tar.gz
 wget http://apache.claz.org/maven/maven-3/$MVN_VERSION/binaries/apache-maven-$MVN_VERSION-bin.tar.gz

--- a/lib/sparkperf/build.py
+++ b/lib/sparkperf/build.py
@@ -60,7 +60,7 @@ def make_spark_distribution(commit_id, target_dir, spark_git_repo, merge_commit_
         # running PySpark on YARN or when running on Java 6.  Since we'll be building and running
         # Spark on the same machines and using standalone mode, it should be safe to
         # disable this warning:
-        run_cmd("./make-distribution.sh --skip-java-test")
+        run_cmd("./make-distribution.sh --skip-java-test -Dhadoop.version=1.0.4")
 
 
 def copy_configuration(conf_dir, target_dir):

--- a/lib/sparkperf/build.py
+++ b/lib/sparkperf/build.py
@@ -60,7 +60,7 @@ def make_spark_distribution(commit_id, target_dir, spark_git_repo, merge_commit_
         # running PySpark on YARN or when running on Java 6.  Since we'll be building and running
         # Spark on the same machines and using standalone mode, it should be safe to
         # disable this warning:
-        run_cmd("./make-distribution.sh --skip-java-test -Dhadoop.version=1.0.4")
+        run_cmd("./make-distribution.sh --skip-java-test -Dhadoop.version=1.2.1 -Phadoop-1")
 
 
 def copy_configuration(conf_dir, target_dir):


### PR DESCRIPTION
The default version of Hadoop that Spark builds against changed around a month or two ago. This PR fixes the version of Hadoop at was it was before that change.

We will probably want to put this somewhere else eventually, maybe make it an option as part of some refactoring in #64.