### PR TITLE
Build with yarn jars if we are running against a yarn cluster.

### DIFF
--- a/lib/sparkperf/build.py
+++ b/lib/sparkperf/build.py
@@ -38,7 +38,7 @@ def checkout_version(repo_dir, commit_id, merge_commit_into_master=False):
             run_cmd("git reset --hard %s" % commit_id)
 
 
-def make_spark_distribution(commit_id, target_dir, spark_git_repo, merge_commit_into_master=False):
+def make_spark_distribution(commit_id, target_dir, spark_git_repo, merge_commit_into_master=False, is_yarn_mode=False):
     """
     Download Spark, check out a specific version, and create a binary distribution.
 
@@ -60,7 +60,10 @@ def make_spark_distribution(commit_id, target_dir, spark_git_repo, merge_commit_
         # running PySpark on YARN or when running on Java 6.  Since we'll be building and running
         # Spark on the same machines and using standalone mode, it should be safe to
         # disable this warning:
-        run_cmd("./make-distribution.sh --skip-java-test")
+        if is_yarn_mode:
+            run_cmd("./make-distribution.sh --skip-java-test -Pyarn")
+        else:
+            run_cmd("./make-distribution.sh --skip-java-test")
 
 
 def copy_configuration(conf_dir, target_dir):
@@ -85,7 +88,7 @@ class SparkBuildManager(object):
         if not os.path.isdir(root_dir):
             os.makedirs(root_dir)
 
-    def get_cluster(self, commit_id, conf_dir, merge_commit_into_master=False):
+    def get_cluster(self, commit_id, conf_dir, merge_commit_into_master=False, is_yarn_mode=False):
         if not os.path.isdir(self._master_spark):
             clone_spark(self._master_spark, self.spark_git_repo)
         # Get the SHA corresponding to the commit and check if we've already built this version:
@@ -102,7 +105,9 @@ class SparkBuildManager(object):
         else:
             logger.info("Could not find pre-compiled Spark with SHA %s" % sha)
             # Check out and build the requested version of Spark in the master spark directory
-            make_spark_distribution(commit_id, self._master_spark, self.spark_git_repo)
+            make_spark_distribution(commit_id, self._master_spark, self.spark_git_repo,
+                                    merge_commit_into_master=merge_commit_into_master,
+                                    is_yarn_mode=is_yarn_mode)
             # Copy the completed build to a directory named after the SHA.
             run_cmd("mv %s %s" % (os.path.join(self._master_spark, "dist"), cluster_dir))
         copy_configuration(conf_dir, cluster_dir)

--- a/lib/sparkperf/main.py
+++ b/lib/sparkperf/main.py
@@ -78,7 +78,7 @@ elif config.USE_CLUSTER_SPARK:
     cluster = Cluster(spark_home=config.SPARK_HOME_DIR, spark_conf_dir=config.SPARK_CONF_DIR)
 else:
     cluster = spark_build_manager.get_cluster(config.SPARK_COMMIT_ID, config.SPARK_CONF_DIR,
-                                              config.SPARK_MERGE_COMMIT_INTO_MASTER)
+                                              config.SPARK_MERGE_COMMIT_INTO_MASTER, config.IS_YARN_MODE)
 
 # rsync Spark to all nodes in case there is a change in Worker config
 if should_restart_cluster and should_rsync_spark_home:


### PR DESCRIPTION
In trying to run spark-perf against a yarn cluster, I noticed it wasn't building with yarn support. Adds -Pyarn if needed.