### PR TITLE
Upgrade to Maven 3.3.3

### DIFF
--- a/bin/spark-ec2/install-maven
+++ b/bin/spark-ec2/install-maven
@@ -2,8 +2,8 @@
 
 # Script for installing Maven on spark-ec2 clusters
 
-MVN_VERSION=3.2.5
-MVN_MD5=b2d88f02bd3a08a9df1f0b0126ebd8dc
+MVN_VERSION=3.3.3
+MVN_MD5=794b3b7961200c542a7292682d21ba36
 
 # wget http://www.apache.org/dyn/closer.cgi/maven/maven-3/$MVN_VERSION/binaries/apache-maven-$MVN_VERSION-bin.tar.gz
 wget http://apache.claz.org/maven/maven-3/$MVN_VERSION/binaries/apache-maven-$MVN_VERSION-bin.tar.gz


### PR DESCRIPTION
Versions of Maven older than 3.3.0 apparently have [a bug in how they handle transitive dependencies](https://github.com/apache/spark/pull/6492#issuecomment-111001101).

I confirmed that upgrading to Maven 3.3.3 resolves at least the particular manifestation of this bug that I ran into.