### PR TITLE
Add perf tests for Gradient-Boosted Decision Trees

### DIFF
--- a/config/config.py.template
+++ b/config/config.py.template
@@ -512,6 +512,22 @@ if MLLIB_SPARK_VERSION >= 1.2:
         # (only used for RandomForest)
         OptionSet("feature-subset-strategy", ["auto"])
     ]
+    MLLIB_DECISION_TREE_TEST_OPTS += [
+        # Ensemble type: GradientBoostedTrees
+        OptionSet("ensemble-type", ["GradientBoostedTrees"]),
+        # Path to training dataset (if not given, use random data).
+        OptionSet("training-data", [""]),
+        # Path to test dataset (only used if training dataset given).
+        # If not given, hold out part of training data for validation.
+        OptionSet("test-data", [""]),
+        # Fraction of data to hold out for testing (ignored if given training and test dataset).
+        OptionSet("test-data-fraction", [0.2], can_scale=False),
+        # Number of trees.
+        OptionSet("num-trees", [10], can_scale=False),
+        #Feature subset sampling strategy: auto, all, sqrt, log2, onethird
+        #(only used for RandomForest)
+        OptionSet("feature-subset-strategy", ["auto"])
+    ]
 
 MLLIB_TESTS += [("decision-tree", MLLIB_PERF_TEST_RUNNER, SCALE_FACTOR,
     MLLIB_JAVA_OPTS, [ConstantOption("decision-tree")] +

--- a/config/config.py.template
+++ b/config/config.py.template
@@ -366,6 +366,10 @@ MLLIB_PERF_TEST_RUNNER = "mllib.perf.TestRunner"
 
 # Set this to 1.0, 1.1, 1.2, ... (the major version) to test MLlib with a particular Spark version.
 # Note: You should also build mllib-perf using -Dspark.version to specify the same version.
+# Note: To run perf tests against a snapshot version of Spark which has not yet been packaged into a release:
+#  * Build Spark locally by running `build/sbt assembly; build/sbt publishLocal` in the Spark root directory
+#  * Set `USE_CLUSTER_SPARK = True` and `MLLIB_SPARK_VERSION = {desired Spark version, e.g. 1.5}`
+#  * Don't use PREP_MLLIB_TESTS = True; instead manually run `cd mllib-tests; sbt/sbt -Dspark.version=1.5.0-SNAPSHOT clean assembly` to build perf tests
 MLLIB_SPARK_VERSION = 1.2
 
 MLLIB_JAVA_OPTS = COMMON_JAVA_OPTS

--- a/config/config.py.template
+++ b/config/config.py.template
@@ -501,8 +501,8 @@ MLLIB_DECISION_TREE_TEST_OPTS = MLLIB_COMMON_OPTS + [
 
 if MLLIB_SPARK_VERSION >= 1.2:
     MLLIB_DECISION_TREE_TEST_OPTS += [
-        # Ensemble type: RandomForest
-        OptionSet("ensemble-type", ["RandomForest"]),
+        # Ensemble type: RandomForest, GradientBoostedTrees
+        OptionSet("ensemble-type", ["RandomForest", "GradientBoostedTrees"]),
         # Path to training dataset (if not given, use random data).
         OptionSet("training-data", [""]),
         # Path to test dataset (only used if training dataset given).
@@ -514,22 +514,6 @@ if MLLIB_SPARK_VERSION >= 1.2:
         OptionSet("num-trees", [1, 10], can_scale=False),
         # Feature subset sampling strategy: auto, all, sqrt, log2, onethird
         # (only used for RandomForest)
-        OptionSet("feature-subset-strategy", ["auto"])
-    ]
-    MLLIB_DECISION_TREE_TEST_OPTS += [
-        # Ensemble type: GradientBoostedTrees
-        OptionSet("ensemble-type", ["GradientBoostedTrees"]),
-        # Path to training dataset (if not given, use random data).
-        OptionSet("training-data", [""]),
-        # Path to test dataset (only used if training dataset given).
-        # If not given, hold out part of training data for validation.
-        OptionSet("test-data", [""]),
-        # Fraction of data to hold out for testing (ignored if given training and test dataset).
-        OptionSet("test-data-fraction", [0.2], can_scale=False),
-        # Number of trees.
-        OptionSet("num-trees", [10], can_scale=False),
-        #Feature subset sampling strategy: auto, all, sqrt, log2, onethird
-        #(only used for RandomForest)
         OptionSet("feature-subset-strategy", ["auto"])
     ]
 

--- a/mllib-tests/v1p5/src/main/scala/mllib/perf/MLAlgorithmTests.scala
+++ b/mllib-tests/v1p5/src/main/scala/mllib/perf/MLAlgorithmTests.scala
@@ -1,23 +1,22 @@
 package mllib.perf
 
-import org.apache.spark.mllib.tree.configuration.{Algo, QuantileStrategy, Strategy, BoostingStrategy}
-import org.apache.spark.mllib.tree.loss.{SquaredError, LogLoss}
-import org.json4s.JsonDSL._
 import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
 
 import org.apache.spark.SparkContext
-import org.apache.spark.SparkContext._
 import org.apache.spark.mllib.classification._
-import org.apache.spark.mllib.clustering.{KMeansModel, KMeans}
+import org.apache.spark.mllib.clustering.{KMeans, KMeansModel}
 import org.apache.spark.mllib.linalg.{Vector, Vectors}
-import org.apache.spark.mllib.recommendation.{Rating, MatrixFactorizationModel, ALS}
+import org.apache.spark.mllib.recommendation.{ALS, MatrixFactorizationModel, Rating}
 import org.apache.spark.mllib.regression._
-import org.apache.spark.mllib.tree.impurity.{Variance, Gini}
 import org.apache.spark.mllib.tree.{GradientBoostedTrees, RandomForest}
+import org.apache.spark.mllib.tree.configuration.{Algo, BoostingStrategy, QuantileStrategy, Strategy}
+import org.apache.spark.mllib.tree.impurity.{Gini, Variance}
+import org.apache.spark.mllib.tree.loss.{LogLoss, SquaredError}
 import org.apache.spark.mllib.tree.model.{GradientBoostedTreesModel, RandomForestModel}
 import org.apache.spark.rdd.RDD
 
-import mllib.perf.util.{DataLoader, DataGenerator}
+import mllib.perf.util.{DataGenerator, DataLoader}
 
 /** Parent class for tests which run on a large dataset. */
 abstract class RegressionAndClassificationTests[M](sc: SparkContext) extends PerfTest {
@@ -609,7 +608,7 @@ class DecisionTreeTest(sc: SparkContext) extends DecisionTreeTests(sc) {
           Left(RandomForest.trainClassifier(rdd, labelType, categoricalFeaturesInfo, numTrees,
             featureSubsetStrategy, "gini", treeDepth, maxBins, this.getRandomSeed))
         case "GradientBoostedTrees" =>
-          val treeStrategy = new Strategy(Algo.Classification, Gini, treeDepth,
+          val treeStrategy = new Strategy(Algo.Classification, Variance, treeDepth,
             labelType, maxBins, QuantileStrategy.Sort, categoricalFeaturesInfo)
           val boostingStrategy = BoostingStrategy(treeStrategy, LogLoss, numTrees,
             learningRate = 0.1)


### PR DESCRIPTION
@jkbradley please review after #79 merges 

Adds performance tests for GBDT under shared decision-tree test infrastructure.