### PR TITLE
Add spark.ml Tree perf tests

### DIFF
--- a/config/config.py.template
+++ b/config/config.py.template
@@ -509,17 +509,17 @@ if MLLIB_SPARK_VERSION >= 1.2:
         # Ensemble type: mllib.RandomForest, mllib.GradientBoostedTrees,
         #                ml.RandomForest, ml.GradientBoostedTrees
         OptionSet("ensemble-type", ensembleTypes),
-         #Path to training dataset (if not given, use random data).
+        # Path to training dataset (if not given, use random data).
         OptionSet("training-data", [""]),
-         #Path to test dataset (only used if training dataset given).
-         #If not given, hold out part of training data for validation.
+        # Path to test dataset (only used if training dataset given).
+        # If not given, hold out part of training data for validation.
         OptionSet("test-data", [""]),
-         #Fraction of data to hold out for testing (ignored if given training and test dataset).
+        # Fraction of data to hold out for testing (ignored if given training and test dataset).
         OptionSet("test-data-fraction", [0.2], can_scale=False),
-         #Number of trees. If 1, then run DecisionTree. If >1, then run RandomForest.
+        # Number of trees. If 1, then run DecisionTree. If >1, then run RandomForest.
         OptionSet("num-trees", [1, 10], can_scale=False),
-         #Feature subset sampling strategy: auto, all, sqrt, log2, onethird
-         #(only used for RandomForest)
+        # Feature subset sampling strategy: auto, all, sqrt, log2, onethird
+        # (only used for RandomForest)
         OptionSet("feature-subset-strategy", ["auto"])
     ]
 

--- a/config/config.py.template
+++ b/config/config.py.template
@@ -500,9 +500,9 @@ MLLIB_DECISION_TREE_TEST_OPTS = MLLIB_COMMON_OPTS + [
 ]
 
 if MLLIB_SPARK_VERSION >= 1.2:
-    ensembleTypes = ["mllib.RandomForest"]
+    ensembleTypes = ["RandomForest"]
     if MLLIB_SPARK_VERSION >= 1.3:
-        ensembleTypes.append("mllib.GradientBoostedTrees")
+        ensembleTypes.append("GradientBoostedTrees")
     if MLLIB_SPARK_VERSION >= 1.4:
         ensembleTypes.extend(["ml.RandomForest", "ml.GradientBoostedTrees"])
     MLLIB_DECISION_TREE_TEST_OPTS += [

--- a/config/config.py.template
+++ b/config/config.py.template
@@ -500,20 +500,26 @@ MLLIB_DECISION_TREE_TEST_OPTS = MLLIB_COMMON_OPTS + [
 ]
 
 if MLLIB_SPARK_VERSION >= 1.2:
+    ensembleTypes = ["mllib.RandomForest"]
+    if MLLIB_SPARK_VERSION >= 1.3:
+        ensembleTypes.append("mllib.GradientBoostedTrees")
+    if MLLIB_SPARK_VERSION >= 1.4:
+        ensembleTypes.extend(["ml.RandomForest", "ml.GradientBoostedTrees"])
     MLLIB_DECISION_TREE_TEST_OPTS += [
-        # Ensemble type: RandomForest, GradientBoostedTrees
-        OptionSet("ensemble-type", ["RandomForest", "GradientBoostedTrees"]),
-        # Path to training dataset (if not given, use random data).
+        # Ensemble type: mllib.RandomForest, mllib.GradientBoostedTrees,
+        #                ml.RandomForest, ml.GradientBoostedTrees
+        OptionSet("ensemble-type", ensembleTypes),
+         #Path to training dataset (if not given, use random data).
         OptionSet("training-data", [""]),
-        # Path to test dataset (only used if training dataset given).
-        # If not given, hold out part of training data for validation.
+         #Path to test dataset (only used if training dataset given).
+         #If not given, hold out part of training data for validation.
         OptionSet("test-data", [""]),
-        # Fraction of data to hold out for testing (ignored if given training and test dataset).
+         #Fraction of data to hold out for testing (ignored if given training and test dataset).
         OptionSet("test-data-fraction", [0.2], can_scale=False),
-        # Number of trees. If 1, then run DecisionTree. If >1, then run RandomForest.
+         #Number of trees. If 1, then run DecisionTree. If >1, then run RandomForest.
         OptionSet("num-trees", [1, 10], can_scale=False),
-        # Feature subset sampling strategy: auto, all, sqrt, log2, onethird
-        # (only used for RandomForest)
+         #Feature subset sampling strategy: auto, all, sqrt, log2, onethird
+         #(only used for RandomForest)
         OptionSet("feature-subset-strategy", ["auto"])
     ]
 

--- a/mllib-tests/project/MLlibTestsBuild.scala
+++ b/mllib-tests/project/MLlibTestsBuild.scala
@@ -17,7 +17,7 @@ object MLlibTestsBuild extends Build {
     organization := "org.spark-project",
     version := "0.1",
     scalaVersion := "2.10.4",
-    sparkVersion := sys.props.getOrElse("spark.version", default="1.3.1"),
+    sparkVersion := sys.props.getOrElse("spark.version", default="1.5.0-SNAPSHOT"),
     libraryDependencies ++= Seq(
       "net.sf.jopt-simple" % "jopt-simple" % "4.6",
       "org.scalatest" %% "scalatest" % "2.2.1" % "test",

--- a/mllib-tests/project/MLlibTestsBuild.scala
+++ b/mllib-tests/project/MLlibTestsBuild.scala
@@ -17,7 +17,7 @@ object MLlibTestsBuild extends Build {
     organization := "org.spark-project",
     version := "0.1",
     scalaVersion := "2.10.4",
-    sparkVersion := sys.props.getOrElse("spark.version", default="1.5.0-SNAPSHOT"),
+    sparkVersion := sys.props.getOrElse("spark.version", default="1.3.1"),
     libraryDependencies ++= Seq(
       "net.sf.jopt-simple" % "jopt-simple" % "4.6",
       "org.scalatest" %% "scalatest" % "2.2.1" % "test",

--- a/mllib-tests/v1p5/src/main/scala/mllib/perf/MLAlgorithmTests.scala
+++ b/mllib-tests/v1p5/src/main/scala/mllib/perf/MLAlgorithmTests.scala
@@ -1,10 +1,10 @@
 package mllib.perf
 
-import org.apache.spark.ml.PredictionModel
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 
 import org.apache.spark.SparkContext
+import org.apache.spark.ml.PredictionModel
 import org.apache.spark.ml.classification.{GBTClassificationModel, GBTClassifier, RandomForestClassificationModel, RandomForestClassifier}
 import org.apache.spark.ml.regression.{GBTRegressionModel, GBTRegressor, RandomForestRegressionModel, RandomForestRegressor}
 import org.apache.spark.mllib.classification._
@@ -18,7 +18,7 @@ import org.apache.spark.mllib.tree.impurity.Variance
 import org.apache.spark.mllib.tree.loss.{LogLoss, SquaredError}
 import org.apache.spark.mllib.tree.model.{GradientBoostedTreesModel, RandomForestModel}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+import org.apache.spark.sql.Row
 
 import mllib.perf.util.{DataGenerator, DataLoader}
 


### PR DESCRIPTION
Adds performance tests for Random Forests and GBDTS implemented in ML pipelines API.
 * Adds a coproduct type to support polymorphism in "decision-tree" tests
 * The perf-tests utilize the DataFrame API since the underlying models in ML are private. This makes performance dependent on Spark SQL

@mengxr @jkbradley 