### PR TITLE
Add receiver scheduling policy test for Streaming

### DIFF
--- a/config/config.py.template
+++ b/config/config.py.template
@@ -340,16 +340,13 @@ STREAMING_HDFS_RECOVERY_TEST_OPTS = STREAMING_COMMON_OPTS + streaming_batch_dura
     OptionSet("file-cleaner-delay", [300])
 ]
 
-STREAMING_RECEIVER_LOAD_BALANCE_TEST_OPTS = streaming_batch_duration_opts(2000) + [
-    OptionSet("total-duration", [30]),
-    OptionSet("hdfs-url", [HDFS_URL]),
-    OptionSet("total-executor-cores", [20], can_scale=True),
+STREAMING_RECEIVER_LOAD_BALANCE_TEST_OPTS = STREAMING_COMMON_OPTS + streaming_batch_duration_opts(2000) + [
+    OptionSet("total-executor-cores", [20]),
     OptionSet("num-executors", [5]),
-    OptionSet("num-trials", [5]),
 ]
 
 STREAMING_RECEIVER_FAILURE_TEST_OPTS = STREAMING_COMMON_OPTS + streaming_batch_duration_opts(2000) + [
-    OptionSet("num-receivers", [5], can_scale=True),
+    OptionSet("num-receivers", [5]),
 ]
 
 STREAMING_RECEIVER_TIMEOUT_TEST_OPTS = STREAMING_COMMON_OPTS + streaming_batch_duration_opts(2000) + [

--- a/config/config.py.template
+++ b/config/config.py.template
@@ -340,6 +340,23 @@ STREAMING_HDFS_RECOVERY_TEST_OPTS = STREAMING_COMMON_OPTS + streaming_batch_dura
     OptionSet("file-cleaner-delay", [300])
 ]
 
+STREAMING_RECEIVER_LOAD_BALANCE_TEST_OPTS = streaming_batch_duration_opts(2000) + [
+    OptionSet("total-duration", [30]),
+    OptionSet("hdfs-url", [HDFS_URL]),
+    OptionSet("total-executor-cores", [20], can_scale=True),
+    OptionSet("num-executors", [5]),
+    OptionSet("num-trials", [5]),
+]
+
+STREAMING_RECEIVER_FAILURE_TEST_OPTS = STREAMING_COMMON_OPTS + streaming_batch_duration_opts(2000) + [
+    OptionSet("num-receivers", [5], can_scale=True),
+]
+
+STREAMING_RECEIVER_TIMEOUT_TEST_OPTS = STREAMING_COMMON_OPTS + streaming_batch_duration_opts(2000) + [
+    OptionSet("total-executor-cores", [20]),
+    OptionSet("receiver-timeout", [30 * 1000]),
+]
+
 # This test is just to see if everything is setup properly
 STREAMING_TESTS += [("basic", "streaming.perf.TestRunner", SCALE_FACTOR,
     STREAMING_COMMON_JAVA_OPTS, [ConstantOption("basic")] + STREAMING_COMMON_OPTS + streaming_batch_duration_opts(1000))]
@@ -356,6 +373,14 @@ STREAMING_TESTS += [("reduce-by-key-and-window", "streaming.perf.TestRunner", SC
 STREAMING_TESTS += [("hdfs-recovery", "streaming.perf.TestRunner", SCALE_FACTOR,
     STREAMING_COMMON_JAVA_OPTS, [ConstantOption("hdfs-recovery")] + STREAMING_HDFS_RECOVERY_TEST_OPTS)]
 
+STREAMING_TESTS += [("receiver-load-balance", "streaming.perf.TestRunner", SCALE_FACTOR,
+    STREAMING_COMMON_JAVA_OPTS, [ConstantOption("receiver-load-balance")] + STREAMING_RECEIVER_LOAD_BALANCE_TEST_OPTS)]
+
+STREAMING_TESTS += [("receiver-failure", "streaming.perf.TestRunner", SCALE_FACTOR,
+    STREAMING_COMMON_JAVA_OPTS, [ConstantOption("receiver-failure")] + STREAMING_RECEIVER_FAILURE_TEST_OPTS)]
+
+STREAMING_TESTS += [("receiver-timeout", "streaming.perf.TestRunner", SCALE_FACTOR,
+    STREAMING_COMMON_JAVA_OPTS, [ConstantOption("receiver-timeout")] + STREAMING_RECEIVER_TIMEOUT_TEST_OPTS)]
 
 # ================== #
 #  MLlib Test Setup  #

--- a/streaming-tests/src/main/scala/streaming/perf/ReceiverTest.scala
+++ b/streaming-tests/src/main/scala/streaming/perf/ReceiverTest.scala
@@ -1,0 +1,278 @@
+package streaming.perf
+
+import scala.collection.mutable
+import scala.concurrent.TimeoutException
+
+import org.apache.spark.{SparkEnv, SparkContext, SparkConf}
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.streaming.{Milliseconds, StreamingContext}
+import org.apache.spark.streaming.dstream.DStream
+import org.apache.spark.streaming.receiver.Receiver
+import org.apache.spark.streaming.scheduler._
+
+/**
+ * Try different numbers of receivers and test if we can distribute them evenly.
+ */
+class BasicReceiver extends Receiver[Int](StorageLevel.MEMORY_ONLY) {
+
+  @volatile private var stopped = false
+
+  override def onStart(): Unit = {
+    stopped = false
+    new Thread("BasicReceiver") {
+      override def run(): Unit = {
+        while (!stopped) {
+          Thread.sleep(100)
+        }
+      }
+    }.start()
+  }
+
+  override def onStop(): Unit = {
+    stopped = true
+  }
+}
+
+class ReceiverLoadBalanceTest extends PerfTest {
+
+  val TOTAL_EXECUTOR_CORES = ("total-executor-cores", "the total number of executor codes")
+
+  val NUM_EXECUTORS = ("num-executors", "number of executors")
+
+  val NUM_TRIALS = ("num-trials", "how many tests to run")
+
+  override def longOptions = super.longOptions ++ Seq(TOTAL_EXECUTOR_CORES, NUM_EXECUTORS, NUM_TRIALS)
+
+  override def run(): String = {
+    val totalExecutorCores = longOptionValue(TOTAL_EXECUTOR_CORES).toInt
+    require(totalExecutorCores > 0)
+
+    val numTrials = longOptionValue(NUM_TRIALS).toInt
+    require(numTrials > 0 && numTrials <= totalExecutorCores)
+
+    val numExecutors = longOptionValue(NUM_EXECUTORS).toInt
+    require(numExecutors > 0)
+
+    if (ssc != null) {
+      ssc.stop()
+    }
+    // Select numTrials test cases. It must include "1" and "totalExecutorCores" if "numTrials != 1".
+    // But if "numTrials == 1", just test "totalExecutorCores".
+    val numReceiversTestCases = mutable.ArrayBuffer(1)
+    for (i <- 1 until numTrials if numReceiversTestCases.size < numTrials) {
+      val step = totalExecutorCores / (numTrials - 1)
+      numReceiversTestCases += numReceiversTestCases.last + step
+    }
+    if (numReceiversTestCases.last != totalExecutorCores) {
+      numReceiversTestCases(numReceiversTestCases.size - 1) = totalExecutorCores
+    }
+    for (numReceivers <- numReceiversTestCases) {
+      println(s"Testing $numReceivers receivers")
+      runTest(numReceivers, totalExecutorCores, numExecutors)
+    }
+    "SUCCESS"
+  }
+
+  def runTest(numReceivers: Int, totalExecutorCores: Int, numExecutors: Int): Unit = {
+    require(numReceivers > 0)
+    val ssc = createContext()
+    try {
+      val receiverLocations = new mutable.HashMap[Int, String] with mutable.SynchronizedMap[Int, String]
+      ssc.addStreamingListener(new StreamingListener {
+        override def onReceiverStarted(receiverStarted: StreamingListenerReceiverStarted): Unit = {
+          receiverLocations(receiverStarted.receiverInfo.streamId) = receiverStarted.receiverInfo.location
+        }
+
+        override def onReceiverError(receiverError: StreamingListenerReceiverError): Unit = {
+          receiverLocations -= receiverError.receiverInfo.streamId
+        }
+
+        override def onReceiverStopped(receiverStopped: StreamingListenerReceiverStopped): Unit = {
+          receiverLocations -= receiverStopped.receiverInfo.streamId
+        }
+      })
+
+      var stream: DStream[Int] = null
+      var i = 0
+      while (i < numReceivers) {
+        val receiver = ssc.receiverStream(new BasicReceiver)
+        stream = if (stream == null) receiver else stream.union(receiver)
+        i += 1
+      }
+      stream.print()
+
+      def getExecutorSize: Int = {
+        SparkEnv.get.blockManager.master.getMemoryStatus.filter { case (blockManagerId, _) =>
+          // Ignore the driver location
+          blockManagerId.executorId != "driver" && blockManagerId.executorId != "<driver>"
+        }.size
+      }
+      // We need to wait for all executors up so as to verify the scheduling policy works correctly
+      val startTime = System.currentTimeMillis()
+      val timeoutForExecutors = 30000 // 30 seconds
+      var executorSize = getExecutorSize
+      while (executorSize < numExecutors) {
+        if (System.currentTimeMillis() < startTime + timeoutForExecutors) {
+          Thread.sleep(100)
+        } else {
+          throw new TimeoutException(s"Cannot enough executors (expected $numExecutors, " +
+            s"but was $executorSize) online before starting StreamingContext in $timeoutForExecutors milliseconds")
+        }
+        executorSize = getExecutorSize
+      }
+
+      ssc.start()
+
+      // Assume all receivers should start in totalDurationSec seconds
+      ssc.awaitTermination(totalDurationSec * 1000)
+      if (receiverLocations.size < numReceivers) {
+        throw new AssertionError(s"$numReceivers receivers cannot start in ${totalDurationSec} seconds")
+      }
+      val locationsToNumReceivers = receiverLocations.groupBy(_._2).map { case (location, values) =>
+        (location, values.size)
+      }
+      val minNumReceivers = locationsToNumReceivers.values.min
+      val maxNumReceivers = locationsToNumReceivers.values.min
+      // If it's balanced, maxNumReceivers - minNumReceivers should <= 1
+      if (maxNumReceivers - minNumReceivers > 1) {
+        throw new AssertionError(s"Receivers are not balanced: $receiverLocations $locationsToNumReceivers")
+      }
+      if (numReceivers >= numExecutors && locationsToNumReceivers.size < numExecutors) {
+        // There are more receivers than executors, but the number of locations is less than the number of executors.
+        // It means there are some idle executors and we should fail the test.
+        throw new AssertionError(s"Receivers are not balanced: $receiverLocations $locationsToNumReceivers")
+      }
+    } finally {
+      ssc.stop(true, true)
+    }
+  }
+}
+
+/**
+ * A receiver that will fail until `now` is greater than `failUtil`.
+ */
+class FailureReceiver(failUtil: Long) extends Receiver[Int](StorageLevel.MEMORY_ONLY) {
+
+  @volatile private var stopped = false
+
+  override def onStart(): Unit = {
+    stopped = false
+    new Thread("FailureReceiver") {
+      override def run(): Unit = {
+        if (System.currentTimeMillis() < failUtil) {
+          throw new RuntimeException("Oops")
+        }
+        while (!stopped) {
+          Thread.sleep(100)
+        }
+      }
+    }.start()
+  }
+
+  override def onStop(): Unit = {
+    stopped = true
+  }
+}
+
+/**
+ * Run some receivers that keeps failing and test if we can recovery them when they become stable.
+ */
+class ReceiverFailureTest extends PerfTest {
+
+  val NUM_RECEIVERS = ("num-receivers", "number of receivers")
+
+  override def longOptions = super.longOptions ++ Seq(NUM_RECEIVERS)
+
+  override def run(): String = {
+    val numReceivers = longOptionValue(NUM_RECEIVERS).toInt
+    require(numReceivers > 0)
+
+    // Make receivers fail during the first half of totalDurationSec
+    val failureDuration = totalDurationSec * 1000 / 2
+
+    val receivers = new mutable.HashSet[Int] with mutable.SynchronizedSet[Int]
+    ssc.addStreamingListener(new StreamingListener {
+      override def onReceiverStarted(receiverStarted: StreamingListenerReceiverStarted): Unit = {
+        receivers += receiverStarted.receiverInfo.streamId
+      }
+
+      override def onReceiverError(receiverError: StreamingListenerReceiverError): Unit = {
+        receivers -= receiverError.receiverInfo.streamId
+      }
+
+      override def onReceiverStopped(receiverStopped: StreamingListenerReceiverStopped): Unit = {
+        receivers -= receiverStopped.receiverInfo.streamId
+      }
+    })
+
+    var stream: DStream[Int] = null
+    var i = 0
+    val now = System.currentTimeMillis()
+    while (i < numReceivers) {
+      val receiver = ssc.receiverStream(new FailureReceiver(now + failureDuration))
+      stream = if (stream == null) receiver else stream.union(receiver)
+      i += 1
+    }
+    stream.print()
+    ssc.start()
+    // Assume all receivers should start in totalDurationSec seconds
+    ssc.awaitTermination(totalDurationSec * 1000)
+
+    if (receivers.size != numReceivers) {
+      throw new AssertionError(s"There is only ${receivers.size} remaining. Cannot recovery to $numReceivers")
+    }
+    ssc.stop()
+
+    "SUCCESS"
+  }
+}
+
+
+/**
+ * Run receivers more than executors and see if we can stop StreamingContext.
+ */
+class ReceiverTimeoutTest extends PerfTest {
+
+  val TOTAL_EXECUTOR_CORES = ("total-executor-cores", "the total number of executor codes")
+
+  val RECEIVER_TIMEOUT = ("receiver-timeout", "timeout to launch a receiver")
+
+  override def longOptions = super.longOptions ++ Seq(TOTAL_EXECUTOR_CORES, RECEIVER_TIMEOUT)
+
+  override def run(): String = {
+    if (ssc != null) {
+      ssc.stop()
+    }
+
+    val totalExecutorCores = longOptionValue(TOTAL_EXECUTOR_CORES).toInt
+    require(totalExecutorCores > 0)
+
+    val receiverTimeout = longOptionValue(RECEIVER_TIMEOUT)
+
+    val conf = new SparkConf().setAppName(testName).
+      set("spark.streaming.receiver.launching.timeout", receiverTimeout + "ms")
+    val sparkContext = new SparkContext(conf)
+    ssc = new StreamingContext(sparkContext, Milliseconds(batchDurationMs))
+
+    val numReceivers = totalExecutorCores + 1
+    var stream: DStream[Int] = null
+    var i = 0
+    val now = System.currentTimeMillis()
+    while (i < numReceivers) {
+      val receiver = ssc.receiverStream(new BasicReceiver)
+      stream = if (stream == null) receiver else stream.union(receiver)
+      i += 1
+    }
+    stream.print()
+    ssc.start()
+    try {
+      ssc.awaitTermination(receiverTimeout * 2)
+      throw new AssertionError("There are not enough executor cores for receivers but TimeoutException is not thrown ")
+    } catch {
+      case e: TimeoutException => // This is expected
+    }
+
+    "SUCCESS"
+  }
+}
+


### PR DESCRIPTION
Added tests for the new receiver scheduling policy in 1.5. This PR is for [SPARK-9933: Test the new receiver scheduling](https://issues.apache.org/jira/browse/SPARK-9933).
- ReceiverLoadBalanceTest: test if receivers are load balanced in the beginning by running the app many times and verifying whether they are load balanced. **Failed** when using branch-1.5, **Passed** when using https://github.com/apache/spark/pull/8340
- ReceiverFailureTest: test whether receivers are restarted after any failure, independent of the max task attempts. **Passed**
- ReceiverTimeoutTest: test a timeout after which if all the receivers have not started, it should fail. **Failed** when using branch-1.5, **Passed** when using https://github.com/apache/spark/pull/8242
